### PR TITLE
Update Schema.org blog post to recommend https

### DIFF
--- a/blog/2026-03-09-schema.org.md
+++ b/blog/2026-03-09-schema.org.md
@@ -3,7 +3,7 @@ title: Is it http://schema.org or https://schema.org?
 authors: [coret, ddeboer]
 tags: [rdf]
 last_update:
-  date: 2026-03-26
+  date: 2026-04-02
   author: ddeboer
 ---
 
@@ -16,6 +16,10 @@ But if you’ve worked with Schema.org in RDF, you’ve run into this: **there�
 That one-letter difference can cause real problems:
 SPARQL queries that silently return nothing, SHACL validation that rejects good data or ignores bad data, or datasets that should link up but don’t – especially when combining data from multiple sources, as in NDE.
 
+:::info Update 2 April 2026
+This post originally recommended `http://schema.org/` based on the JSON-LD context behaviour. It sparked exactly the discussion we hoped for: a structured conversation with stakeholders from NDE, CLARIAH, ODISSEI, and heritage institutions on 2 April 2026. The outcome: **a choice was made**. The participants reached consensus on `https://schema.org/`. This post has been updated to reflect that decision – see [the recommendation](/blog/2026/03/09/schema.org/#the-recommendation).
+:::
+
 <!--truncate-->
 
 ## How did this happen?
@@ -27,7 +31,7 @@ But a webpage is not the same as an identifier. Your browser just “ends up” 
 
 As Tim Berners-Lee wrote in [*Axioms of Web Architecture*](https://www.w3.org/DesignIssues/Axioms.html): “the significance of identity for a given URI is determined by the person who owns the URI, who first determined what it points to.” So what did Schema.org’s owner determine?
 
-## Why “both are fine” is misleading
+## Why "both are fine" is misleading
 
 Schema.org’s [FAQ #19](https://schema.org/docs/faq.html#19) says that “both ‘https://schema.org’ and ‘http://schema.org’ are fine” and that “there should be no urgency about migrating existing data,” while noting the site itself has migrated to HTTPS as the default. That advice is accurate for search-engine consumers like Google, which normalize both variants. But for JSON-LD processors and RDF tooling, `http://schema.org/CreativeWork` and `https://schema.org/CreativeWork` are *not* the same – and the JSON-LD context still defines the vocabulary with HTTP identifiers.
 
@@ -88,34 +92,15 @@ JSON-LD 1.1’s [`@import`](https://www.w3.org/TR/json-ld11/#imported-contexts) 
 
 This overrides both `@vocab` and the `schema` prefix, so all terms expand to `https://schema.org/` while preserving type coercions (e.g. `url` and `sameAs` remain IRIs, not plain strings).
 
-If NDE hosted this context at a stable URL, publishers would reference it instead of Schema.org’s default context:
+See [a shared context for consumers](#a-shared-context-for-consumers) for how NDE uses this.
 
-```json
-{
-  "@context": "https://docs.nde.nl/context.jsonld",
-  "@type": "Dataset",
-  "@id": "https://example.org/my-dataset",
-  "name": "My dataset",
-  "publisher": {
-    "@type": "Organization",
-    "name": "My organisation"
-  }
-}
-```
+### The impact is limited
 
-A JSON-LD processor fetches the NDE context, which in turn imports the official Schema.org context with the `https://` overrides. The result: all terms expand to `https://schema.org/` – compare to the [standard context example above](#json-ld-contexts):
+The JSON-LD context mismatch only affects tooling that processes JSON-LD and expands it to RDF triples. It does not affect:
 
-```shell
-echo ‘{"@context":{"@version":1.1,"@import":"https://schema.org/docs/jsonldcontext.jsonld","@vocab":"https://schema.org/","schema":"https://schema.org/"},"@type":"CreativeWork","name":"Example"}’ | riot --syntax=jsonld --output=nquads
-_:B... <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/CreativeWork> .
-_:B... <https://schema.org/name> "Example" .
-```
-
-It’s technically sound: even Google’s [Rich Results Test](https://search.google.com/test/rich-results) correctly processes the `@import` override and recognises the structured data. But there are trade-offs:
-
-- **Partial reach**: the custom context only helps publishers who adopt it. Any JSON-LD published with the standard `"@context": "https://schema.org"` will keep producing `http://` triples – and that includes most Schema.org data on the web.
-- **Normalisation still needed**: consumers combining data from both inside and outside the network would still encounter both variants and need to normalise.
-- **Infrastructure dependency**: publisher data becomes tied to `"@context": "https://docs.nde.nl/context.jsonld"` rather than the self-explanatory `"@context": "https://schema.org"`. If the NDE context is unavailable, processors can’t interpret the data.
+- Data published in **Turtle, N-Triples, or other RDF serializations** – these use full URIs directly, so publishers simply write `https://schema.org/`.
+- **SPARQL queries and SHACL shapes** – these reference full URIs and are unaffected by JSON-LD context behaviour, *as long as* the data they operate on was not expanded from JSON-LD (where the context produces `http://` URIs).
+- **Search engines** like Google, which normalise both variants.
 
 ## What does the community say?
 
@@ -155,22 +140,63 @@ He recently reflected on the HTTP-to-HTTPS transition in his book [*This is for 
 
 The URI scheme change should not have affected identity – but it did. Using HTTP for vocabulary identifiers is not unusual: Dublin Core Terms, for example, uses `http://purl.org/dc/terms/` and has never changed to HTTPS.
 
-## Making a clear choice
+## The recommendation
 
-The [NDE Schema Application Profile](https://docs.nde.nl/schema-profile/) recommends:
+On 2 April 2026, representatives from NDE, research infrastructures (CLARIAH, ODISSEI), and heritage institutions (IISG and others) reached consensus: **use `https://schema.org/`**.
 
-- Publishers **SHOULD** use `http://schema.org/`, because that’s what the JSON-LD context resolves to and what aligns with the canonical vocabulary.
-- Consumers **MUST** accept both HTTP and HTTPS variants. A large amount of Schema.org data already exists in the wild using HTTPS – including vocabularies like [PiCo](https://personsincontext.org/model/) – and refusing it would mean ignoring perfectly valid datasets.
+The arguments that tipped the balance:
 
-This is an NDE interoperability recommendation tied to the current JSON-LD context behaviour, not a universal policy. If Schema.org migrates its context to HTTPS, this recommendation would change accordingly.
+- **Future-proof.** Schema.org's own [FAQ](https://schema.org/docs/faq.html#19) signals HTTPS as the preferred direction. Choosing HTTP now would risk a second migration if Schema.org completes that transition.
+- **Easier to communicate.** Telling institutions to use `http://` – while their browsers show `https://` – invites confusion and requires explaining the identifier-vs-transport distinction every time. HTTPS is simply easier to sell to decision-makers, practitioners, and IT departments. That may sound subjective, but in a network that depends on voluntary adoption, it matters.
+- **Network effect.** Vocabularies like [PiCo](https://personsincontext.org/model/) and tools like [rdflib](https://github.com/RDFLib/rdflib/blob/53405b7354e3ba90e6633f88a435e0eac5880f44/rdflib/namespace/_SDO.py#L16) already use `https://schema.org/`. Aligning with them strengthens interoperability across NDE, CLARIAH, ODISSEI, and beyond.
+- **A choice beats no choice.** The biggest risk was not picking the ‘wrong’ protocol – it was not picking at all. Every month without a decision means more data published in both variants, making eventual convergence harder and more expensive.
 
-The rationale is documented in [schema-profile#45](https://github.com/netwerk-digitaal-erfgoed/schema-profile/issues/45). This pragmatic approach follows the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle): be strict in what you publish, liberal in what you accept.
+The [NDE Schema Application Profile](https://docs.nde.nl/schema-profile/) now recommends:
 
+| | Protocol | Requirement level |
+| --- | --- | --- |
+| **New datasets** | `https://schema.org/` | MUST |
+| **Existing datasets** | `https://schema.org/` | SHOULD |
+| **Consumers** | Accept both | MUST (NDE provides [tooling](#a-shared-context-for-consumers) to normalise) |
+
+- **New datasets** MUST use `https://schema.org/` URIs.
+- **Existing datasets** SHOULD migrate to `https://schema.org/`. We recognise that migration takes time and will work with institutions to establish a realistic timeline.
+- **Consumers** MUST accept both `http://` and `https://` variants. NDE will provide tooling (e.g. the [shared JSON-LD context](#a-shared-context-for-consumers)) to normalise to `https://schema.org/`.
+
+This follows the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle): be strict in what you publish, liberal in what you accept.
+
+### A shared context for consumers
+
+For the JSON-LD case, rather than requiring every data publisher to adopt a custom context, **the responsibility sits with consumers**. Publishers keep using the standard `"@context": "https://schema.org"` – no extra dependencies. Consumers apply a shared context when processing incoming JSON-LD data, rewriting `http://` terms to `https://` at ingestion time.
+
+NDE provides [this context](https://docs.nde.nl/schema.org/context.jsonld) using the [`@import`](#what-about-a-custom-context) mechanism described above. Consumers replace the context of incoming documents before expansion:
+
+```javascript
+// Node (jsonld.js)
+document['@context'] = 'https://docs.nde.nl/schema.org/context.jsonld';
+const expanded = await jsonld.expand(document);
+```
+
+```python
+# Python (pyld)
+document["@context"] = "https://docs.nde.nl/schema.org/context.jsonld"
+expanded = jsonld.expand(document)
+```
+
+This approach is **stack-independent**: one URL that works in any JSON-LD 1.1 processor, regardless of language or platform. No per-stack stream transforms needed.
+
+### Upstream dependencies
+
+Some upstream standards like [RO-Crate](https://www.researchobject.org/ro-crate/) and [CodeMeta](https://codemeta.github.io/) still use `http://schema.org/` URIs. This doesn't affect the NDE recommendation directly – our [Requirements for Datasets](https://docs.nde.nl/schema-profile/) already use `https://` – but it means consumers may still encounter `http://` data from sources outside the NDE network. This is another reason why consumer-side normalisation matters.
+
+Valid arguments exist on both sides – and that is unlikely to change. What matters is that **a shared choice, consistently applied, is worth more than the theoretically optimal choice that no one agrees on**.
 
 ## Conclusion
 
-The community may eventually converge on HTTPS, but until Schema.org’s JSON-LD context reflects that change, using HTTP remains the **most interoperable choice**. When publishing structured data: use `http://schema.org/`. When consuming it: accept both.
+The community has chosen `https://schema.org/` as the canonical form for Schema.org URIs in the Dutch cultural heritage network. The [JSON-LD context mismatch](#the-impact-is-limited) is a real but limited issue, addressed by a [shared consumer-side context](#a-shared-context-for-consumers). When publishing structured data: use `https://schema.org/`. When consuming it: accept both and normalise to `https://`.
+
+The rationale is documented in [schema-profile#45](https://github.com/netwerk-digitaal-erfgoed/schema-profile/issues/45).
 
 ---
 
-*This post was updated following valuable feedback from Ivo Zandhuis, Richard Zijdeman, Leon van Wissen, and others.*
+*This post was updated following a community decision on 2 April 2026. The original version recommended `http://schema.org/` – the updated recommendation is `https://schema.org/`. Thanks to participants from heritage institutions, research infrastructures, and academia – and to Ivo Zandhuis, Richard Zijdeman, and Leon van Wissen for their early feedback.*

--- a/blog/2026-03-09-schema.org.md
+++ b/blog/2026-03-09-schema.org.md
@@ -17,7 +17,7 @@ That one-letter difference can cause real problems:
 SPARQL queries that silently return nothing, SHACL validation that rejects good data or ignores bad data, or datasets that should link up but don’t – especially when combining data from multiple sources, as in NDE.
 
 :::info Update 2 April 2026
-This post originally recommended `http://schema.org/` based on the JSON-LD context behaviour. It sparked exactly the discussion we hoped for: a structured conversation with stakeholders from NDE, CLARIAH, ODISSEI, and heritage institutions on 2 April 2026. The outcome: **a choice was made**. The participants reached consensus on `https://schema.org/`. This post has been updated to reflect that decision – see [the recommendation](/blog/2026/03/09/schema.org/#the-recommendation).
+This post originally recommended `http://schema.org/` (HTTP) based on reasons outlined below. It sparked exactly the discussion we hoped for: a structured conversation with stakeholders from NDE, CLARIAH, ODISSEI, and heritage institutions. On 2 April 2026, participants reached consensus on `https://schema.org/` (HTTPS). This post has been updated to reflect that decision – see [the recommendation](/blog/2026/03/09/schema.org/#the-recommendation).
 :::
 
 <!--truncate-->
@@ -31,7 +31,7 @@ But a webpage is not the same as an identifier. Your browser just “ends up” 
 
 As Tim Berners-Lee wrote in [*Axioms of Web Architecture*](https://www.w3.org/DesignIssues/Axioms.html): “the significance of identity for a given URI is determined by the person who owns the URI, who first determined what it points to.” So what did Schema.org’s owner determine?
 
-## Why "both are fine" is misleading
+## Why “both are fine” is misleading
 
 Schema.org’s [FAQ #19](https://schema.org/docs/faq.html#19) says that “both ‘https://schema.org’ and ‘http://schema.org’ are fine” and that “there should be no urgency about migrating existing data,” while noting the site itself has migrated to HTTPS as the default. That advice is accurate for search-engine consumers like Google, which normalize both variants. But for JSON-LD processors and RDF tooling, `http://schema.org/CreativeWork` and `https://schema.org/CreativeWork` are *not* the same – and the JSON-LD context still defines the vocabulary with HTTP identifiers.
 
@@ -146,21 +146,15 @@ On 2 April 2026, representatives from NDE, research infrastructures (CLARIAH, OD
 
 The arguments that tipped the balance:
 
-- **Future-proof.** Schema.org's own [FAQ](https://schema.org/docs/faq.html#19) signals HTTPS as the preferred direction. Choosing HTTP now would risk a second migration if Schema.org completes that transition.
-- **Easier to communicate.** Telling institutions to use `http://` – while their browsers show `https://` – invites confusion and requires explaining the identifier-vs-transport distinction every time. HTTPS is simply easier to sell to decision-makers, practitioners, and IT departments. That may sound subjective, but in a network that depends on voluntary adoption, it matters.
+- **Future-proof.** Schema.org’s own [FAQ](https://schema.org/docs/faq.html#19) signals HTTPS as the preferred direction. Choosing HTTP now would risk a second migration if Schema.org completes that transition.
+- **Easier to communicate.** Telling institutions to use `http://` – while their browsers show `https://` – invites confusion and requires explaining the identifier-vs-transport distinction every time.
 - **Network effect.** Vocabularies like [PiCo](https://personsincontext.org/model/) and tools like [rdflib](https://github.com/RDFLib/rdflib/blob/53405b7354e3ba90e6633f88a435e0eac5880f44/rdflib/namespace/_SDO.py#L16) already use `https://schema.org/`. Aligning with them strengthens interoperability across NDE, CLARIAH, ODISSEI, and beyond.
-- **A choice beats no choice.** The biggest risk was not picking the ‘wrong’ protocol – it was not picking at all. Every month without a decision means more data published in both variants, making eventual convergence harder and more expensive.
+
 
 The [NDE Schema Application Profile](https://docs.nde.nl/schema-profile/) now recommends:
 
-| | Protocol | Requirement level |
-| --- | --- | --- |
-| **New datasets** | `https://schema.org/` | MUST |
-| **Existing datasets** | `https://schema.org/` | SHOULD |
-| **Consumers** | Accept both | MUST (NDE provides [tooling](#a-shared-context-for-consumers) to normalise) |
-
 - **New datasets** MUST use `https://schema.org/` URIs.
-- **Existing datasets** SHOULD migrate to `https://schema.org/`. We recognise that migration takes time and will work with institutions to establish a realistic timeline.
+- **Existing datasets** SHOULD migrate to `https://schema.org/`.
 - **Consumers** MUST accept both `http://` and `https://` variants. NDE will provide tooling (e.g. the [shared JSON-LD context](#a-shared-context-for-consumers)) to normalise to `https://schema.org/`.
 
 This follows the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle): be strict in what you publish, liberal in what you accept.
@@ -183,19 +177,16 @@ document["@context"] = "https://docs.nde.nl/schema.org/context.jsonld"
 expanded = jsonld.expand(document)
 ```
 
-This approach is **stack-independent**: one URL that works in any JSON-LD 1.1 processor, regardless of language or platform. No per-stack stream transforms needed.
+This approach is **stack-independent**: one URL that works in any JSON-LD 1.1 processor, regardless of language or platform. No per-stack stream transforms needed. Alternatively, consumers can [inline the context](#what-about-a-custom-context) to avoid the external dependency.
 
 ### Upstream dependencies
 
-Some upstream standards like [RO-Crate](https://www.researchobject.org/ro-crate/) and [CodeMeta](https://codemeta.github.io/) still use `http://schema.org/` URIs. This doesn't affect the NDE recommendation directly – our [Requirements for Datasets](https://docs.nde.nl/schema-profile/) already use `https://` – but it means consumers may still encounter `http://` data from sources outside the NDE network. This is another reason why consumer-side normalisation matters.
-
-Valid arguments exist on both sides – and that is unlikely to change. What matters is that **a shared choice, consistently applied, is worth more than the theoretically optimal choice that no one agrees on**.
+Some upstream standards like [RO-Crate](https://www.researchobject.org/ro-crate/) and [CodeMeta](https://codemeta.github.io/) still use `http://schema.org/` URIs. This doesn’t affect the NDE recommendation directly – our [Requirements for Datasets](https://docs.nde.nl/schema-profile/) already use `https://` – but it means consumers may still encounter `http://` data from sources outside the NDE network. This is another reason why consumer-side normalisation matters.
 
 ## Conclusion
 
 The community has chosen `https://schema.org/` as the canonical form for Schema.org URIs in the Dutch cultural heritage network. The [JSON-LD context mismatch](#the-impact-is-limited) is a real but limited issue, addressed by a [shared consumer-side context](#a-shared-context-for-consumers). When publishing structured data: use `https://schema.org/`. When consuming it: accept both and normalise to `https://`.
 
-The rationale is documented in [schema-profile#45](https://github.com/netwerk-digitaal-erfgoed/schema-profile/issues/45).
 
 ---
 

--- a/blog/2026-03-09-schema.org.md
+++ b/blog/2026-03-09-schema.org.md
@@ -128,7 +128,7 @@ A common argument for HTTPS identifiers is security: shouldn’t we fetch vocabu
 
 ## What about dereferenceability?
 
-Schema.org URIs aren’t just opaque strings – they *do* resolve to useful definitions, and that dereferenceability is a core Linked Data principle. You can look up what `CreativeWork` means, what properties it has, and how it relates to other types. This remains fully functional with HTTP identifiers: you still get the definitions, still over a secure connection. What matters for interoperability is that everyone uses the *same* identifier, whichever scheme it uses – and right now, the canonical one is HTTP.
+Schema.org URIs aren’t just opaque strings – they *do* resolve to useful definitions, and that dereferenceability is a core Linked Data principle. You can look up what `CreativeWork` means, what properties it has, and how it relates to other types. This remains fully functional with HTTP identifiers: you still get the definitions, still over a secure connection. What matters for interoperability is that everyone uses the *same* identifier, whichever scheme it uses.
 
 ## Cool URIs don’t change
 
@@ -149,7 +149,6 @@ The arguments that tipped the balance:
 - **Future-proof.** Schema.org’s own [FAQ](https://schema.org/docs/faq.html#19) signals HTTPS as the preferred direction. Choosing HTTP now would risk a second migration if Schema.org completes that transition.
 - **Easier to communicate.** Telling institutions to use `http://` – while their browsers show `https://` – invites confusion and requires explaining the identifier-vs-transport distinction every time.
 - **Network effect.** Vocabularies like [PiCo](https://personsincontext.org/model/) and tools like [rdflib](https://github.com/RDFLib/rdflib/blob/53405b7354e3ba90e6633f88a435e0eac5880f44/rdflib/namespace/_SDO.py#L16) already use `https://schema.org/`. Aligning with them strengthens interoperability across NDE, CLARIAH, ODISSEI, and beyond.
-
 
 The [NDE Schema Application Profile](https://docs.nde.nl/schema-profile/) now recommends:
 
@@ -185,8 +184,7 @@ Some upstream standards like [RO-Crate](https://www.researchobject.org/ro-crate/
 
 ## Conclusion
 
-The community has chosen `https://schema.org/` as the canonical form for Schema.org URIs in the Dutch cultural heritage network. The [JSON-LD context mismatch](#the-impact-is-limited) is a real but limited issue, addressed by a [shared consumer-side context](#a-shared-context-for-consumers). When publishing structured data: use `https://schema.org/`. When consuming it: accept both and normalise to `https://`.
-
+`https://schema.org/` is the canonical form for Schema.org URIs in the Dutch cultural heritage network. The [JSON-LD context mismatch](#the-impact-is-limited) is a real but limited issue, addressed by a [shared consumer-side context](#a-shared-context-for-consumers). When publishing structured data: use `https://schema.org/`. When consuming it: accept both and normalise to `https://`.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the Schema.org blog post to reflect the HTTPS recommendation from the 2 April 2026 meeting:

- Add update banner explaining the changed recommendation
- Rewrite recommendation section: MUST `https://` for new datasets, SHOULD for existing, consumers accept both
- Add shared JSON-LD context section for consumer-side normalisation, with inline fallback
- Group meeting participants by sector (NDE, research infrastructures, heritage institutions)
- Add SHACL caveat for JSON-LD-expanded data
- Frame upstream dependencies (RO-Crate, CodeMeta) as non-blocking
- Remove redundant/hedging language, stale references, and leftover HTTP-era claims
