### PR TITLE
docs: update Dutch Schema.org blog post to recommend HTTPS

### DIFF
--- a/i18n/nl/docusaurus-plugin-content-blog/2026-03-09-schema.org.md
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-03-09-schema.org.md
@@ -3,7 +3,7 @@ title: Is het http://schema.org of https://schema.org?
 authors: [coret, ddeboer]
 tags: [rdf]
 last_update:
-  date: 2026-03-26
+  date: 2026-04-02
   author: ddeboer
 ---
 
@@ -15,6 +15,10 @@ Correct gebruik maakt cultureel-erfgoeddata vindbaar en herbruikbaar tussen inst
 Maar als je met Schema.org in RDF hebt gewerkt, ben je dit tegengekomen: **er is `http://schema.org` en er is `https://schema.org`**.
 Dat ene lettertje verschil kan voor echte problemen zorgen:
 SPARQL-query’s die niets teruggeven, SHACL-validatie die goede data afwijst of slechte data negeert, of datasets die niet aan elkaar te koppelen zijn – vooral als je data uit meerdere bronnen combineert, zoals binnen NDE gebeurt.
+
+:::info Update 2 april 2026
+Deze post adviseerde oorspronkelijk `http://schema.org/` (HTTP) op basis van de hieronder beschreven redenen. Dat leidde tot precies de discussie die we hoopten: een gestructureerd gesprek met betrokkenen van NDE, CLARIAH, ODISSEI en erfgoedinstellingen. Op 2 april 2026 bereikten de deelnemers consensus over `https://schema.org/` (HTTPS). Deze post is bijgewerkt om dat besluit te weerspiegelen \u2013 zie [de aanbeveling](/blog/2026/03/09/schema.org/#de-aanbeveling).
+:::
 
 <!--truncate-->
 
@@ -89,34 +93,15 @@ Met JSON-LD 1.1's [`@import`](https://www.w3.org/TR/json-ld11/#imported-contexts
 
 Dit overschrijft zowel `@vocab` als het `schema`-prefix, waardoor alle termen expanderen naar `https://schema.org/` met behoud van type-coercions (bijv. `url` en `sameAs` blijven IRI's, geen platte strings).
 
-Als NDE deze context op een stabiele URL zou hosten, verwijzen bronhouders daarnaar in plaats van naar de standaard Schema.org-context:
+Zie [een gedeelde context voor afnemers](#een-gedeelde-context-voor-afnemers) voor hoe NDE dit toepast.
 
-```json
-{
-  "@context": "https://docs.nde.nl/context.jsonld",
-  "@type": "Dataset",
-  "@id": "https://example.org/my-dataset",
-  "name": "Mijn dataset",
-  "publisher": {
-    "@type": "Organization",
-    "name": "Mijn organisatie"
-  }
-}
-```
+### De impact is beperkt
 
-Een JSON-LD-processor haalt de NDE-context op, die op zijn beurt de officiële Schema.org-context importeert met de `https://`-overrides. Het resultaat: alle termen expanderen naar `https://schema.org/` – vergelijk met het [standaard-contextvoorbeeld hierboven](#json-ld-contexten-wijzen-naar-http):
+De JSON-LD-contextmismatch raakt alleen tooling die JSON-LD verwerkt en expandeert naar RDF-triples. Het raakt niet:
 
-```shell
-echo '{"@context":{"@version":1.1,"@import":"https://schema.org/docs/jsonldcontext.jsonld","@vocab":"https://schema.org/","schema":"https://schema.org/"},"@type":"CreativeWork","name":"Example"}' | riot --syntax=jsonld --output=nquads
-_:B... <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/CreativeWork> .
-_:B... <https://schema.org/name> "Example" .
-```
-
-De aanpak is technisch correct: zelfs Google's [Rich Results Test](https://search.google.com/test/rich-results) verwerkt de `@import`-override correct en herkent de gestructureerde data. Maar er zijn nadelen:
-
-- **Beperkt bereik**: de aangepaste context helpt alleen bronhouders die deze overnemen. JSON-LD gepubliceerd met de standaard `"@context": "https://schema.org"` blijft `http://`-triples produceren – en dat geldt voor het overgrote deel van Schema.org-data op het web.
-- **Normalisatie blijft nodig**: consumenten die data van binnen en buiten het netwerk combineren, komen nog steeds beide varianten tegen en moeten normaliseren.
-- **Afhankelijkheid van infrastructuur**: data van bronhouders wordt gebonden aan `"@context": "https://docs.nde.nl/context.jsonld"` in plaats van het vanzelfsprekende `"@context": "https://schema.org"`. Als de NDE-context niet beschikbaar is, kunnen processors de data niet interpreteren.
+- Data gepubliceerd in **Turtle, N-Triples of andere RDF-serialisaties** \u2013 die gebruiken volledige URI’s, dus bronhouders schrijven gewoon `https://schema.org/`.
+- **SPARQL-query’s en SHACL-shapes** \u2013 die verwijzen naar volledige URI’s en worden niet be\u00EFnvloed door JSON-LD-contextgedrag, *zolang* de data waarop ze werken niet is ge\u00EBxpandeerd vanuit JSON-LD (waar de context `http://`-URI’s produceert).
+- **Zoekmachines** zoals Google, die beide varianten normaliseren.
 
 ## Wat zegt de community?
 
@@ -144,7 +129,7 @@ Een veelgehoord argument voor HTTPS-identifiers is beveiliging: moeten we vocabu
 
 ## Hoe zit het met dereferenceerbaarheid?
 
-Schema.org-URI's zijn niet zomaar ondoorzichtige strings – ze verwijzen wél naar bruikbare definities, en die dereferenceerbaarheid is een kernprincipe van linked data. Je kunt opzoeken wat `CreativeWork` betekent, welke eigenschappen het heeft en hoe het zich verhoudt tot andere typen. Dat werkt volledig met HTTP-identifiers: je krijgt gewoon de definities, gewoon via een beveiligde verbinding. Wat telt voor interoperabiliteit is dat iedereen *dezelfde* identifier gebruikt, welk URI-schema die ook heeft – en op dit moment is de canonieke vorm HTTP.
+Schema.org-URI's zijn niet zomaar ondoorzichtige strings – ze verwijzen wél naar bruikbare definities, en die dereferenceerbaarheid is een kernprincipe van linked data. Je kunt opzoeken wat `CreativeWork` betekent, welke eigenschappen het heeft en hoe het zich verhoudt tot andere typen. Dat werkt volledig met HTTP-identifiers: je krijgt gewoon de definities, gewoon via een beveiligde verbinding. Wat telt voor interoperabiliteit is dat iedereen *dezelfde* identifier gebruikt, welk URI-schema die ook heeft.
 
 ## Cool URI’s veranderen niet
 
@@ -156,21 +141,52 @@ Recent keek hij terug op de overgang van HTTP naar HTTPS in zijn boek [*This is 
 
 De wijziging van het URI-schema had de identiteit niet mogen aantasten – maar dat deed het wel. Het gebruik van HTTP voor vocabulaire-identifiers is overigens heel gewoon: Dublin Core Terms gebruikt `http://purl.org/dc/terms/` en is nooit overgestapt naar HTTPS.
 
-## Een duidelijke keuze
+## De aanbeveling
 
-Het [NDE Schema-applicatieprofiel](https://docs.nde.nl/schema-profile/) adviseert:
+Op 2 april 2026 bereikten vertegenwoordigers van NDE, onderzoeksinfrastructuren (CLARIAH, ODISSEI) en erfgoedinstellingen (IISG en anderen) consensus: **gebruik `https://schema.org/`**.
 
-- Bronhouders gebruiken bij voorkeur (**SHOULD**) `http://schema.org/`, omdat de JSON-LD-context daarnaar verwijst en het overeenkomt met het canonieke vocabulaire.
-- Consumenten **MOETEN** (helaas) beide varianten accepteren. Er is veel Schema.org-data in omloop die HTTPS gebruikt – waaronder vocabulaires als [PiCo](https://personsincontext.org/model/) – en wie die weigert, sluit valide datasets uit.
+De argumenten die de doorslag gaven:
 
-Dit is een interoperabiliteitsadvies gekoppeld aan het huidige gedrag van de JSON-LD-context, geen universeel beleid. Mocht Schema.org zijn context naar HTTPS migreren, dan verandert dit advies mee.
+- **Toekomstbestendig.** Schema.org’s eigen [FAQ](https://schema.org/docs/faq.html#19) wijst HTTPS aan als de gewenste richting. Nu HTTP kiezen zou een tweede migratie riskeren als Schema.org die transitie voltooit.
+- **Makkelijker te communiceren.** Instellingen vertellen dat ze `http://` moeten gebruiken \u2013 terwijl hun browser `https://` toont \u2013 leidt tot verwarring en vereist telkens uitleg over het verschil tussen identifier en transport.
+- **Netwerkeffect.** Vocabulaires zoals [PiCo](https://personsincontext.org/model/) en tools zoals [rdflib](https://github.com/RDFLib/rdflib/blob/53405b7354e3ba90e6633f88a435e0eac5880f44/rdflib/namespace/_SDO.py#L16) gebruiken al `https://schema.org/`. Aansluiten versterkt de interoperabiliteit binnen NDE, CLARIAH, ODISSEI en daarbuiten.
 
-De onderbouwing staat in [schema-profile#45](https://github.com/netwerk-digitaal-erfgoed/schema-profile/issues/45). Deze pragmatische aanpak volgt het [robuustheidsprincipe](https://en.wikipedia.org/wiki/Robustness_principle): publiceer strikt, accepteer ruim.
+Het [NDE Schema-applicatieprofiel](https://docs.nde.nl/schema-profile/) adviseert nu:
+
+- **Nieuwe datasets** MOETEN `https://schema.org/`-URI’s gebruiken.
+- **Bestaande datasets** zouden naar `https://schema.org/` moeten migreren (SHOULD).
+- **Afnemers** MOETEN beide varianten (`http://` en `https://`) accepteren. NDE biedt tooling (zoals de [gedeelde JSON-LD-context](#een-gedeelde-context-voor-afnemers)) om te normaliseren naar `https://schema.org/`.
+
+Dit volgt het [robuustheidsprincipe](https://en.wikipedia.org/wiki/Robustness_principle): publiceer strikt, accepteer ruim.
+
+### Een gedeelde context voor afnemers
+
+Bij JSON-LD ligt de verantwoordelijkheid niet bij de bronhouder maar bij de **afnemer**. Bronhouders blijven gewoon `"@context": "https://schema.org"` gebruiken \u2013 geen extra afhankelijkheden. Afnemers passen een gedeelde context toe bij het verwerken van binnenkomende JSON-LD-data, waarmee `http://`-termen worden herschreven naar `https://` bij inname.
+
+NDE biedt [deze context](https://docs.nde.nl/schema.org/context.jsonld) aan via het [`@import`](#kan-een-eigen-context-helpen)-mechanisme dat hierboven is beschreven. Afnemers vervangen de context van binnenkomende documenten v\u00F3\u00F3r expansie:
+
+```javascript
+// Node (jsonld.js)
+document['@context'] = 'https://docs.nde.nl/schema.org/context.jsonld';
+const expanded = await jsonld.expand(document);
+```
+
+```python
+# Python (pyld)
+document["@context"] = "https://docs.nde.nl/schema.org/context.jsonld"
+expanded = jsonld.expand(document)
+```
+
+Deze aanpak is **stack-onafhankelijk**: \u00E9\u00E9n URL die werkt in elke JSON-LD 1.1-processor, ongeacht taal of platform. Geen stream transforms per stack nodig. Als alternatief kunnen afnemers de [context inline opnemen](#kan-een-eigen-context-helpen) om de externe afhankelijkheid te vermijden.
+
+### Upstream-afhankelijkheden
+
+Sommige upstream-standaarden zoals [RO-Crate](https://www.researchobject.org/ro-crate/) en [CodeMeta](https://codemeta.github.io/) gebruiken nog `http://schema.org/`-URI’s. Dit raakt de NDE-aanbeveling niet direct \u2013 onze [Requirements for Datasets](https://docs.nde.nl/schema-profile/) gebruiken al `https://` \u2013 maar het betekent dat afnemers nog `http://`-data kunnen tegenkomen van bronnen buiten het NDE-netwerk. Dit is nog een reden waarom normalisatie aan de afnemerskant belangrijk is.
 
 ## Conclusie
 
-De community zal mogelijk uiteindelijk overgaan op HTTPS, maar zolang de JSON-LD-context van Schema.org dat niet weerspiegelt, blijft HTTP de **meest interoperabele keuze**. Bij het publiceren van gestructureerde data: gebruik `http://schema.org/`. Bij het consumeren: accepteer beide.
+`https://schema.org/` is de canonieke vorm voor Schema.org-URI’s in het Nederlandse cultureel-erfgoednetwerk. De [JSON-LD-contextmismatch](#de-impact-is-beperkt) is een re\u00EBel maar beperkt probleem, opgelost door een [gedeelde context voor afnemers](#een-gedeelde-context-voor-afnemers). Bij het publiceren van gestructureerde data: gebruik `https://schema.org/`. Bij het consumeren: accepteer beide en normaliseer naar `https://`.
 
 ---
 
-*Deze post is bijgewerkt naar aanleiding van waardevolle feedback van Ivo Zandhuis, Richard Zijdeman, Leon van Wissen en anderen.*
+*Deze post is bijgewerkt naar aanleiding van een besluit op 2 april 2026. De oorspronkelijke versie adviseerde `http://schema.org/` \u2013 de bijgewerkte aanbeveling is `https://schema.org/`. Met dank aan deelnemers vanuit erfgoedinstellingen, onderzoeksinfrastructuren en de academische wereld \u2013 en aan Ivo Zandhuis, Richard Zijdeman en Leon van Wissen voor hun vroege feedback.*

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-03-09-schema.org.md
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-03-09-schema.org.md
@@ -17,7 +17,7 @@ Dat ene lettertje verschil kan voor echte problemen zorgen:
 SPARQL-query’s die niets teruggeven, SHACL-validatie die goede data afwijst of slechte data negeert, of datasets die niet aan elkaar te koppelen zijn – vooral als je data uit meerdere bronnen combineert, zoals binnen NDE gebeurt.
 
 :::info Update 2 april 2026
-Deze post adviseerde oorspronkelijk `http://schema.org/` (HTTP) op basis van de hieronder beschreven redenen. Dat leidde tot precies de discussie die we hoopten: een gestructureerd gesprek met betrokkenen van NDE, CLARIAH, ODISSEI en erfgoedinstellingen. Op 2 april 2026 bereikten de deelnemers consensus over `https://schema.org/` (HTTPS). Deze post is bijgewerkt om dat besluit te weerspiegelen \u2013 zie [de aanbeveling](/blog/2026/03/09/schema.org/#de-aanbeveling).
+Deze post adviseerde oorspronkelijk `http://schema.org/` (HTTP) op basis van de hieronder beschreven redenen. Dat leidde tot precies de discussie die we hoopten: een gestructureerd gesprek met betrokkenen van NDE, CLARIAH, ODISSEI en erfgoedinstellingen. Op 2 april 2026 bereikten de deelnemers consensus over `https://schema.org/` (HTTPS). Deze post is bijgewerkt om dat besluit te weerspiegelen – zie [de aanbeveling](/blog/2026/03/09/schema.org/#de-aanbeveling).
 :::
 
 <!--truncate-->
@@ -99,8 +99,8 @@ Zie [een gedeelde context voor afnemers](#een-gedeelde-context-voor-afnemers) vo
 
 De JSON-LD-contextmismatch raakt alleen tooling die JSON-LD verwerkt en expandeert naar RDF-triples. Het raakt niet:
 
-- Data gepubliceerd in **Turtle, N-Triples of andere RDF-serialisaties** \u2013 die gebruiken volledige URI’s, dus bronhouders schrijven gewoon `https://schema.org/`.
-- **SPARQL-query’s en SHACL-shapes** \u2013 die verwijzen naar volledige URI’s en worden niet be\u00EFnvloed door JSON-LD-contextgedrag, *zolang* de data waarop ze werken niet is ge\u00EBxpandeerd vanuit JSON-LD (waar de context `http://`-URI’s produceert).
+- Data gepubliceerd in **Turtle, N-Triples of andere RDF-serialisaties** – die gebruiken volledige URI’s, dus bronhouders schrijven gewoon `https://schema.org/`.
+- **SPARQL-query’s en SHACL-shapes** – die verwijzen naar volledige URI’s en worden niet beïnvloed door JSON-LD-contextgedrag, *zolang* de data waarop ze werken niet is geëxpandeerd vanuit JSON-LD (waar de context `http://`-URI’s produceert).
 - **Zoekmachines** zoals Google, die beide varianten normaliseren.
 
 ## Wat zegt de community?
@@ -148,7 +148,7 @@ Op 2 april 2026 bereikten vertegenwoordigers van NDE, onderzoeksinfrastructuren 
 De argumenten die de doorslag gaven:
 
 - **Toekomstbestendig.** Schema.org’s eigen [FAQ](https://schema.org/docs/faq.html#19) wijst HTTPS aan als de gewenste richting. Nu HTTP kiezen zou een tweede migratie riskeren als Schema.org die transitie voltooit.
-- **Makkelijker te communiceren.** Instellingen vertellen dat ze `http://` moeten gebruiken \u2013 terwijl hun browser `https://` toont \u2013 leidt tot verwarring en vereist telkens uitleg over het verschil tussen identifier en transport.
+- **Makkelijker te communiceren.** Instellingen vertellen dat ze `http://` moeten gebruiken – terwijl hun browser `https://` toont – leidt tot verwarring en vereist telkens uitleg over het verschil tussen identifier en transport.
 - **Netwerkeffect.** Vocabulaires zoals [PiCo](https://personsincontext.org/model/) en tools zoals [rdflib](https://github.com/RDFLib/rdflib/blob/53405b7354e3ba90e6633f88a435e0eac5880f44/rdflib/namespace/_SDO.py#L16) gebruiken al `https://schema.org/`. Aansluiten versterkt de interoperabiliteit binnen NDE, CLARIAH, ODISSEI en daarbuiten.
 
 Het [NDE Schema-applicatieprofiel](https://docs.nde.nl/schema-profile/) adviseert nu:
@@ -161,9 +161,9 @@ Dit volgt het [robuustheidsprincipe](https://en.wikipedia.org/wiki/Robustness_pr
 
 ### Een gedeelde context voor afnemers
 
-Bij JSON-LD ligt de verantwoordelijkheid niet bij de bronhouder maar bij de **afnemer**. Bronhouders blijven gewoon `"@context": "https://schema.org"` gebruiken \u2013 geen extra afhankelijkheden. Afnemers passen een gedeelde context toe bij het verwerken van binnenkomende JSON-LD-data, waarmee `http://`-termen worden herschreven naar `https://` bij inname.
+Bij JSON-LD ligt de verantwoordelijkheid niet bij de bronhouder maar bij de **afnemer**. Bronhouders blijven gewoon `"@context": "https://schema.org"` gebruiken – geen extra afhankelijkheden. Afnemers passen een gedeelde context toe bij het verwerken van binnenkomende JSON-LD-data, waarmee `http://`-termen worden herschreven naar `https://` bij inname.
 
-NDE biedt [deze context](https://docs.nde.nl/schema.org/context.jsonld) aan via het [`@import`](#kan-een-eigen-context-helpen)-mechanisme dat hierboven is beschreven. Afnemers vervangen de context van binnenkomende documenten v\u00F3\u00F3r expansie:
+NDE biedt [deze context](https://docs.nde.nl/schema.org/context.jsonld) aan via het [`@import`](#kan-een-eigen-context-helpen)-mechanisme dat hierboven is beschreven. Afnemers vervangen de context van binnenkomende documenten vóór expansie:
 
 ```javascript
 // Node (jsonld.js)
@@ -177,16 +177,16 @@ document["@context"] = "https://docs.nde.nl/schema.org/context.jsonld"
 expanded = jsonld.expand(document)
 ```
 
-Deze aanpak is **stack-onafhankelijk**: \u00E9\u00E9n URL die werkt in elke JSON-LD 1.1-processor, ongeacht taal of platform. Geen stream transforms per stack nodig. Als alternatief kunnen afnemers de [context inline opnemen](#kan-een-eigen-context-helpen) om de externe afhankelijkheid te vermijden.
+Deze aanpak is **stack-onafhankelijk**: één URL die werkt in elke JSON-LD 1.1-processor, ongeacht taal of platform. Geen stream transforms per stack nodig. Als alternatief kunnen afnemers de [context inline opnemen](#kan-een-eigen-context-helpen) om de externe afhankelijkheid te vermijden.
 
 ### Upstream-afhankelijkheden
 
-Sommige upstream-standaarden zoals [RO-Crate](https://www.researchobject.org/ro-crate/) en [CodeMeta](https://codemeta.github.io/) gebruiken nog `http://schema.org/`-URI’s. Dit raakt de NDE-aanbeveling niet direct \u2013 onze [Requirements for Datasets](https://docs.nde.nl/schema-profile/) gebruiken al `https://` \u2013 maar het betekent dat afnemers nog `http://`-data kunnen tegenkomen van bronnen buiten het NDE-netwerk. Dit is nog een reden waarom normalisatie aan de afnemerskant belangrijk is.
+Sommige upstream-standaarden zoals [RO-Crate](https://www.researchobject.org/ro-crate/) en [CodeMeta](https://codemeta.github.io/) gebruiken nog `http://schema.org/`-URI’s. Dit raakt de NDE-aanbeveling niet direct – onze [Requirements for Datasets](https://docs.nde.nl/schema-profile/) gebruiken al `https://` – maar het betekent dat afnemers nog `http://`-data kunnen tegenkomen van bronnen buiten het NDE-netwerk. Dit is nog een reden waarom normalisatie aan de afnemerskant belangrijk is.
 
 ## Conclusie
 
-`https://schema.org/` is de canonieke vorm voor Schema.org-URI’s in het Nederlandse cultureel-erfgoednetwerk. De [JSON-LD-contextmismatch](#de-impact-is-beperkt) is een re\u00EBel maar beperkt probleem, opgelost door een [gedeelde context voor afnemers](#een-gedeelde-context-voor-afnemers). Bij het publiceren van gestructureerde data: gebruik `https://schema.org/`. Bij het consumeren: accepteer beide en normaliseer naar `https://`.
+`https://schema.org/` is de canonieke vorm voor Schema.org-URI’s in het Nederlandse cultureel-erfgoednetwerk. De [JSON-LD-contextmismatch](#de-impact-is-beperkt) is een reëel maar beperkt probleem, opgelost door een [gedeelde context voor afnemers](#een-gedeelde-context-voor-afnemers). Bij het publiceren van gestructureerde data: gebruik `https://schema.org/`. Bij het consumeren: accepteer beide en normaliseer naar `https://`.
 
 ---
 
-*Deze post is bijgewerkt naar aanleiding van een besluit op 2 april 2026. De oorspronkelijke versie adviseerde `http://schema.org/` \u2013 de bijgewerkte aanbeveling is `https://schema.org/`. Met dank aan deelnemers vanuit erfgoedinstellingen, onderzoeksinfrastructuren en de academische wereld \u2013 en aan Ivo Zandhuis, Richard Zijdeman en Leon van Wissen voor hun vroege feedback.*
+*Deze post is bijgewerkt naar aanleiding van een besluit op 2 april 2026. De oorspronkelijke versie adviseerde `http://schema.org/` – de bijgewerkte aanbeveling is `https://schema.org/`. Met dank aan deelnemers vanuit erfgoedinstellingen, onderzoeksinfrastructuren en de academische wereld – en aan Ivo Zandhuis, Richard Zijdeman en Leon van Wissen voor hun vroege feedback.*


### PR DESCRIPTION
## Summary

Updates the Dutch translation of the Schema.org blog post to match the English version, reflecting the HTTPS recommendation from the 2 April 2026 meeting:

- Add update banner explaining the changed recommendation
- Replace publisher-side custom context with consumer-side shared context
- Add "De impact is beperkt" section with SHACL caveat for JSON-LD-expanded data
- Rewrite recommendation: MUST `https://` for new datasets, SHOULD for existing, consumers accept both
- Add shared context for consumers and upstream dependencies sections
- Remove leftover HTTP-era claims and stale references
