### PR TITLE
feat: respect system color scheme preference

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -86,6 +86,9 @@ const config: Config = {
   themeConfig: {
     // Replace with your project's social card
     image: 'img/docusaurus-social-card.jpg',
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     navbar: {
       title: 'Netwerk Digitaal Erfgoed',
       logo: {


### PR DESCRIPTION
## Summary

Enable `respectPrefersColorScheme` in the Docusaurus theme config so the site follows the visitor’s OS light/dark preference on first visit. The navbar toggle now cycles through system → light → dark, and "system" clears the stored override so the OS preference takes over again.
