### PR TITLE
build: migrate onBrokenMarkdownLinks and register requirements tag

### DIFF
--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -21,3 +21,7 @@ persistent-http-uris:
 services:
   label: "Services"
   permalink: /services
+
+requirements:
+  label: "Requirements"
+  permalink: /requirements

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -21,10 +21,12 @@ const config: Config = {
   projectName: 'netwerk-digitaal-erfgoed.github.io', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
 
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
   },
 
   themes: ['@docusaurus/theme-mermaid'],


### PR DESCRIPTION
## Summary

- **Migrate `onBrokenMarkdownLinks`** from the top-level siteConfig into `siteConfig.markdown.hooks`, per the Docusaurus v4 deprecation warning surfaced in the build output.
- **Register the `requirements` tag** in `blog/tags.yml`. It is used by the v2.0 Requirements post (`blog/2026-04-15-dataset-description-requirements.md`, merged in #52) and currently triggers a "Tags [requirements] ... are not defined in tags.yml" warning in both the `en` and `nl` locales.
