### PR TITLE
docs(blog): note that the validation page has been redesigned

### DIFF
--- a/blog/2026-01-12-dataset-register-website.md
+++ b/blog/2026-01-12-dataset-register-website.md
@@ -63,8 +63,8 @@ With these updates, we pay close attention to user interface and experience:
 
 ## Next step
 
-We regularly receive questions from publishers about the [validation page](https://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=http%3A%2F%2Fdata.beeldengeluid.nl%2Fid%2Fdataset%2F0029),
-making it a logical candidate for the next improvement.
+The [validation page](https://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=http%3A%2F%2Fdata.beeldengeluid.nl%2Fid%2Fdataset%2F0029) has now been redesigned as well,
+making it easier for publishers to check their dataset descriptions before registering.
 
 ## Technical details
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-01-12-dataset-register-website.md
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-01-12-dataset-register-website.md
@@ -59,8 +59,8 @@ Bij deze vernieuwingen besteden we veel aandacht aan de gebruikersinterface en -
 
 ## Vervolg
 
-Over de [validatiepagina](https://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=http%3A%2F%2Fdata.beeldengeluid.nl%2Fid%2Fdataset%2F0029) krijgen we regelmatig vragen van uitgevers, 
-wat haar een logische kandidaat maakt voor de volgende verbetering.
+Inmiddels is ook de [validatiepagina](https://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url=http%3A%2F%2Fdata.beeldengeluid.nl%2Fid%2Fdataset%2F0029) vernieuwd,
+zodat uitgevers hun datasetbeschrijvingen eenvoudiger kunnen controleren voordat ze deze aanmelden.
 
 ## Techniek
 


### PR DESCRIPTION
Update the "Next step" / "Vervolg" section of the Dataset Register website blog post (EN and NL) to reflect that the redesigned validation page is now live, instead of being listed as a future candidate.
