### PR TITLE
docs(network-of-terms): document languages parameter fallback

### DIFF
--- a/docs/services/network-of-terms/graphql.md
+++ b/docs/services/network-of-terms/graphql.md
@@ -392,6 +392,18 @@ to see which languages are available for each source.
 
 :::
 
+### Language fallback
+
+The `languages` parameter filters labels per term – it does not exclude terms from the results.
+If a term has no labels in any of the preferred languages, it is still returned, but its label fields
+(`prefLabel`, `altLabel`, `hiddenLabel`, `definition`, `scopeNote`) fall back as follows:
+
+* If the source provides untagged literals for the field, they are returned and treated as Dutch (`nl`).
+* Otherwise, the field is returned as an empty list.
+
+The languages you can actually get back depend on what each source provides: see the `inLanguage`
+field when [listing sources](#list-terminology-sources).
+
 ## Response times
 
 Response times from the Network of Terms will vary depending on how fast each terminology source returns results for the


### PR DESCRIPTION
## Summary

Adds a “Language fallback” subsection to the Network of Terms GraphQL API page, documenting how the `languages` parameter affects responses:

- The parameter filters labels per term – terms themselves are never excluded.
- If a term has no labels in any of the preferred languages, untagged literals are returned as Dutch (`nl`); otherwise the label field comes back empty.
- Available languages depend on what each source provides – cross-references the existing `inLanguage` field on `Source`.

Companion change in `network-of-terms`: netwerk-digitaal-erfgoed/network-of-terms#1851.
