### PR TITLE
docs(blog): acknowledge linked-data trade-off in schema.org HTTPS recommendation

### DIFF
--- a/blog/2026-03-09-schema.org.md
+++ b/blog/2026-03-09-schema.org.md
@@ -17,7 +17,7 @@ That one-letter difference can cause real problems:
 SPARQL queries that silently return nothing, SHACL validation that rejects good data or ignores bad data, or datasets that should link up but don’t – especially when combining data from multiple sources, as in NDE.
 
 :::info Update 2 April 2026
-This post originally recommended `http://schema.org/` (HTTP) based on reasons outlined below. It sparked exactly the discussion we hoped for: a structured conversation with stakeholders from NDE, CLARIAH, ODISSEI, and heritage institutions. On 2 April 2026, participants reached consensus on `https://schema.org/` (HTTPS). This post has been updated to reflect that decision – see [the recommendation](/blog/2026/03/09/schema.org/#the-recommendation).
+This post originally recommended `http://schema.org/` (HTTP) based on reasons outlined below. It sparked exactly the discussion we hoped for: a structured conversation with stakeholders from NDE, CLARIAH, ODISSEI, and heritage institutions. On 2 April 2026, participants reached consensus on `https://schema.org/` (HTTPS). We acknowledge that this recommendation goes against one of the core principles of linked data – cool URIs don’t change – but force of circumstance and pragmatic considerations have led us to advise HTTPS for Schema.org metadata going forward. This post has been updated to reflect that decision – see [the recommendation](/blog/2026/03/09/schema.org/#the-recommendation).
 :::
 
 <!--truncate-->
@@ -144,6 +144,8 @@ The URI scheme change should not have affected identity – but it did. Using HT
 
 On 2 April 2026, representatives from NDE, research infrastructures (CLARIAH, ODISSEI), and heritage institutions (IISG and others) reached consensus: **use `https://schema.org/`**.
 
+We don’t take this lightly. Changing the URI for an established vocabulary goes against [Cool URIs don’t change](#cool-uris-dont-change), one of the core principles of linked data. Still, by force of circumstance and on the strength of the pragmatic arguments below, we recommend HTTPS for Schema.org metadata.
+
 The arguments that tipped the balance:
 
 - **Future-proof.** Schema.org’s own [FAQ](https://schema.org/docs/faq.html#19) signals HTTPS as the preferred direction. Choosing HTTP now would risk a second migration if Schema.org completes that transition.
@@ -184,7 +186,7 @@ Some upstream standards like [RO-Crate](https://www.researchobject.org/ro-crate/
 
 ## Conclusion
 
-`https://schema.org/` is the canonical form for Schema.org URIs in the Dutch cultural heritage network. The [JSON-LD context mismatch](#the-impact-is-limited) is a real but limited issue, addressed by a [shared consumer-side context](#a-shared-context-for-consumers). When publishing structured data: use `https://schema.org/`. When consuming it: accept both and normalise to `https://`.
+`https://schema.org/` is the canonical form for Schema.org URIs in the Dutch cultural heritage network. That recommendation comes with an honest caveat: it goes against [Cool URIs don’t change](#cool-uris-dont-change). We make it only because the alternative – an indefinite split between `http://` and `https://` across the network – does more day-to-day harm to interoperability than holding the line on the principle would prevent. The [JSON-LD context mismatch](#the-impact-is-limited) is a real but limited issue, addressed by a [shared consumer-side context](#a-shared-context-for-consumers). When publishing structured data: use `https://schema.org/`. When consuming it: accept both and normalise to `https://`. And for institutions whose graphs make migration a significant project: take the time you need – existing `http://schema.org/` data is not wrong, and the network is built to accept it.
 
 ---
 


### PR DESCRIPTION
Updates the framing of the Schema.org HTTPS recommendation in [the blog post](https://docs.nde.nl/nl/blog/2026/03/09/schema.org/) based on feedback from René Voorburg (RAZU).

The substance of the recommendation is unchanged – `https://schema.org/` for new datasets, SHOULD-migrate for existing ones, consumers MUST accept both. What changes is the framing: we now state explicitly that the recommendation goes against *Cool URIs don’t change*, and that we make it only by force of circumstance and on the strength of the pragmatic arguments listed.

Three touch-points:

- **Update banner (2 April 2026):** adds the “we acknowledge this goes against a core principle of linked data” caveat.
- **The recommendation section:** new short paragraph up front owning the trade-off before listing the pragmatic arguments.
- **Conclusion:** restated with the same honest caveat, plus an explicit note that existing `http://schema.org/` data is not wrong and the network is built to accept it – aimed at institutions for whom migration is a significant project.

@renevoorburg – flagging for your review before publication, as discussed. Happy to iterate on wording.
