### PR TITLE
feat(config): enable SPARQL and Turtle syntax highlighting

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -188,6 +188,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['turtle', 'sparql'],
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
## Summary

- Add `sparql` and `turtle` to Prism's `additionalLanguages` so RDF code blocks render with syntax highlighting.
- Load order matters: Prism's `sparql` definition extends `turtle`, so `turtle` must come first or the build fails with `Cannot set properties of undefined (setting 'boolean')`.

This unlocks proper highlighting on:
- `services/dataset-register/sparql.md` (SPARQL CONSTRUCT and SELECT queries)
- `services/dataset-register/data-model.md` (Turtle snippets and SPARQL examples in the upcoming pages)
- `services/dataset-knowledge-graph/index.md` (SPARQL examples for the Knowledge Graph)
- `publish/linked-data.md` (SPARQL smoke-test query)
- Future tutorial / how-to pages that include RDF code blocks

## Test plan

- [x] `npm run build` passes for both `en` and `nl` locales (verified via pre-commit hook).
- [ ] After deploy, verify SPARQL highlighting on `services/dataset-register/sparql.md` (existing SPARQL block).
- [ ] After deploy, verify Turtle highlighting in any page containing a `\`\`\`turtle` block.
