### PR TITLE
fix(docs): update Registrations graph link to current QLever query ID

### DIFF
--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -115,7 +115,7 @@ dataset description that consumers query.
 ### `schema:EntryPoint`
 
 Any URL [registered by clients](api.md) is added as a `schema:EntryPoint` to the
-[Registrations graph](https://qlever.netwerkdigitaalerfgoed.nl/chqohW?exec=true).
+[Registrations graph](https://qlever.netwerkdigitaalerfgoed.nl/datasetregister/NwXonb?exec=true).
 
 Datasets are fetched from this URL on registration and when the crawler runs.
 
@@ -132,7 +132,7 @@ Datasets are fetched from this URL on registration and when the crawler runs.
 
 Each dataset that is found at the `schema:EntryPoint` registration URL gets added as a
 `schema:Dataset` to the
-[Registrations graph](https://qlever.netwerkdigitaalerfgoed.nl/datasetregister/chqohW?exec=true).
+[Registrations graph](https://qlever.netwerkdigitaalerfgoed.nl/datasetregister/NwXonb?exec=true).
 
 | Property                                           | Description                                                     |
 | -------------------------------------------------- | --------------------------------------------------------------- |


### PR DESCRIPTION
Both `Registrations graph` links in the Dataset Register data model page pointed at the old QLever query IDs (`chqohW`). Updated to the current ID `NwXonb`: <https://qlever.netwerkdigitaalerfgoed.nl/datasetregister/NwXonb?exec=true>.

## Test plan

- [x] `npm run build` passes for both `en` and `nl` locales (via pre-commit hook).
- [ ] After deploy, click both `Registrations graph` links on <https://docs.nde.nl/services/dataset-register/data-model> and confirm they open the correct QLever query.