### PR TITLE
docs(network-of-terms): document query templates, reconciliation discovery, OpenRefine usage

### DIFF
--- a/docs/services/network-of-terms/graphql.md
+++ b/docs/services/network-of-terms/graphql.md
@@ -335,6 +335,27 @@ query {
 }
 ```
 
+Each URI is routed to the source whose `url` prefix it starts with. Sources declare one or more URL prefixes in the catalog, and the Network of Terms picks the matching source for every URI in the request. If no source claims the prefix, the `source` field returns an `Error` for that URI.
+
+## Discover reconciliation endpoints
+
+Sources that offer a [Reconciliation API](reconciliation.md) advertise it via the `features` field. Each feature has a `type` and a `url`; the entry with `type: RECONCILIATION` carries the endpoint URL to configure in OpenRefine.
+
+```graphql title="List reconciliation endpoints"
+query {
+  sources {
+    uri
+    name
+    features {
+      type
+      url
+    }
+  }
+}
+```
+
+Filter client-side for entries where `type` equals `RECONCILIATION`. Sources that publish their own reconciliation service (such as Wikidata) are not re-exposed here – see [Reconciliation API](reconciliation.md) for details.
+
 ## Language selection
 
 The Network of Terms exposes natural-language data through two distinct controls,

--- a/docs/services/network-of-terms/index.md
+++ b/docs/services/network-of-terms/index.md
@@ -57,3 +57,5 @@ If you just want to search the Network of Terms using a web interface, have a lo
 ## Source code
 
 The Network of Terms is open source software, available [on GitHub](https://github.com/netwerk-digitaal-erfgoed/network-of-terms).
+
+These docs cover **using** the Network of Terms: the GraphQL and Reconciliation APIs, the demonstrator, and the list of available terminology sources. For **running, hosting or extending** the software – install steps, environment variables, the catalog data model, query authoring and the test suite – see the [`network-of-terms` repository README](https://github.com/netwerk-digitaal-erfgoed/network-of-terms#readme) and the README of each package under it.

--- a/docs/services/network-of-terms/reconciliation.md
+++ b/docs/services/network-of-terms/reconciliation.md
@@ -14,10 +14,17 @@ of the specification is still a draft and is not yet supported.
 If you want to use the Reconciliation Service API, configure one or more service endpoints in your
 [OpenRefine](https://openrefine.org) application. An endpoint’s URL is structured like
 `https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/{sourceUri}`. A full list of endpoints can be found on
-the [Network of Terms website](https://termennetwerk.netwerkdigitaalerfgoed.nl/reconciliation).
+the [Network of Terms website](https://termennetwerk.netwerkdigitaalerfgoed.nl/reconciliation), or
+discovered programmatically via the GraphQL API – see [Discover reconciliation endpoints](graphql.md#discover-reconciliation-endpoints).
 
 Note that the Network of Terms provides Reconciliation endpoints only for terminology sources that do not offer such
 endpoints themselves.
+
+## Using the API from OpenRefine
+
+In OpenRefine, open the column you want to reconcile and choose **Reconcile → Start reconciling…**. The first time you use a Network of Terms endpoint, click **Add standard service…** and paste the endpoint URL for the source (for example `https://termennetwerk-api.netwerkdigitaalerfgoed.nl/reconcile/https://data.cultureelerfgoed.nl/term/id/cht`). OpenRefine remembers the service for subsequent projects.
+
+In the reconciliation dialog, select **Reconcile against no particular type**. Network of Terms endpoints don’t advertise a default type for their candidates, and leaving the default option (“Reconcile against the suggested type”) selected makes OpenRefine match every cell against an empty type set, so no candidates come back. Picking “no particular type” lets the source’s own search query decide what counts as a match.
 
 ## Language selection
 

--- a/docs/services/network-of-terms/terminology-sources.md
+++ b/docs/services/network-of-terms/terminology-sources.md
@@ -19,26 +19,8 @@ Most importantly:
 
 If you’d like to add a source to the Network, please consult the [FAQ](https://termennetwerk.netwerkdigitaalerfgoed.nl/faq2). The technical steps – dataset description, SPARQL search and lookup queries, and SHACL validation – live in the [catalog README](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/blob/master/packages/catalog/README.md#adding-a-dataset).
 
-## Writing SPARQL queries for a source
+## Query authoring
 
-Each source in the catalog ships with a SPARQL `CONSTRUCT` query for searching and another for [looking up terms by URI](graphql.md#look-up-terms-by-uri). The Network of Terms substitutes a placeholder variable at runtime with the value the client sent in the GraphQL `query` argument:
+Source-specific search and lookup queries (the SPARQL `CONSTRUCT` queries the Network of Terms federates over the source’s endpoint, including template placeholders such as `?query` / `?virtuosoQuery` and recommended full-text patterns per backend) are documented next to the catalog code: see [Writing the SPARQL queries](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/blob/master/packages/catalog/README.md#writing-the-sparql-queries) in the catalog README.
 
-* `?query` – the search string after the default `OPTIMIZED` preprocessing (lowercased and trimmed). Use this in most SPARQL endpoints.
-* `?virtuosoQuery` – the same string, but with each token wrapped in quotes and joined with `AND`, so it can be passed straight to Virtuoso’s `bif:contains` full-text operator.
-
-Both variables are always available; pick whichever fits the endpoint’s full-text syntax. Lookup queries use `VALUES ?uri { ?uris }` instead, where `?uris` is replaced with the list of URIs to resolve.
-
-Clients can opt out of preprocessing per request by setting `queryMode: RAW` on the GraphQL `terms` query, in which case the search string is passed through to `?query` and `?virtuosoQuery` unchanged. The default is `OPTIMIZED`.
-
-## Full-text search
-
-Terms are matched against textual search strings. Plain SPARQL `FILTER(CONTAINS(…))` works but scans every candidate literal on every request – fine for tiny vocabularies, painful for anything larger. **Prefer the endpoint’s native full-text index** whenever the SPARQL backend offers one: the federated query stays fast enough to keep the Network of Terms’ overall response time in budget.
-
-Common patterns:
-
-* **Apache Jena Fuseki** – [`text:query`](https://jena.apache.org/documentation/query/text-query.html), e.g. `(?uri ?score) text:query (<field> ?query 100)`.
-* **GraphDB (Lucene plugin)** – `?uri luc:term ?query` for labels and IDs, `?uri luc:text ?query` to also include scope notes. See [full-text search](https://graphdb.ontotext.com/documentation/10.8/full-text-search.html).
-* **GraphDB (Lucene connector)** – named indexes via `luc:query` / `luc:entities`; list configured connectors with `?cntUri luc:listConnectors ?cntStr`.
-* **GraphDB (Elasticsearch connector)** – same pattern under the `elastic:` namespace.
-* **OpenLink Virtuoso** – [`bif:contains`](https://docs.openlinksw.com/virtuoso/bifcontainsoptions/), e.g. `?label bif:contains ?virtuosoQuery` (see [`?virtuosoQuery`](#writing-sparql-queries-for-a-source)).
-* **Wikidata** – the `wikibase:mwapi` service with `mwapi:search` (titles) or `mwapi:srsearch` (full text). See the [Wikidata MWAPI manual](https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual/MWAPI).
+The `queryMode` GraphQL argument is the client-facing knob: the default `OPTIMIZED` mode lowercases and trims the input before substitution; `RAW` passes it through unchanged.

--- a/docs/services/network-of-terms/terminology-sources.md
+++ b/docs/services/network-of-terms/terminology-sources.md
@@ -19,14 +19,26 @@ Most importantly:
 
 If you’d like to add a source to the Network, please consult the [FAQ](https://termennetwerk.netwerkdigitaalerfgoed.nl/faq2).
 
-## Fulltext search
+## Writing SPARQL queries for a source
 
-Terms are searched using textual strings. 
-While this is possible with plain SPARQL (`CONTAINS`), search performance can be improved by using the SPARQL’s endpoint fulltext search support,
-usually backed by Lucene.
+Each source in the catalog ships with a SPARQL `CONSTRUCT` query for searching and another for [looking up terms by URI](graphql.md#look-up-terms-by-uri). The Network of Terms substitutes a placeholder variable at runtime with the value the client sent in the GraphQL `query` argument:
 
-Fulltext search is supported by:
+* `?query` – the search string after the default `OPTIMIZED` preprocessing (lowercased and trimmed). Use this in most SPARQL endpoints.
+* `?virtuosoQuery` – the same string, but with each token wrapped in quotes and joined with `AND`, so it can be passed straight to Virtuoso’s `bif:contains` full-text operator.
 
-* [Fuseki](https://jena.apache.org/documentation/query/text-query.html) (`text:query`)
-* [GraphDB](https://graphdb.ontotext.com/documentation/10.8/full-text-search.html) 
-* [Virtuoso](https://docs.openlinksw.com/virtuoso/bifcontainsoptions/) (`bif:contains`)
+Both variables are always available; pick whichever fits the endpoint’s full-text syntax. Lookup queries use `VALUES ?uri { ?uris }` instead, where `?uris` is replaced with the list of URIs to resolve.
+
+Clients can opt out of preprocessing per request by setting `queryMode: RAW` on the GraphQL `terms` query, in which case the search string is passed through to `?query` and `?virtuosoQuery` unchanged. The default is `OPTIMIZED`.
+
+## Full-text search
+
+Terms are matched against textual search strings. Plain SPARQL `FILTER(CONTAINS(…))` works but scans every candidate literal on every request – fine for tiny vocabularies, painful for anything larger. **Prefer the endpoint’s native full-text index** whenever the SPARQL backend offers one: the federated query stays fast enough to keep the Network of Terms’ overall response time in budget.
+
+Common patterns:
+
+* **Apache Jena Fuseki** – [`text:query`](https://jena.apache.org/documentation/query/text-query.html), e.g. `(?uri ?score) text:query (<field> ?query 100)`.
+* **GraphDB (Lucene plugin)** – `?uri luc:term ?query` for labels and IDs, `?uri luc:text ?query` to also include scope notes. See [full-text search](https://graphdb.ontotext.com/documentation/10.8/full-text-search.html).
+* **GraphDB (Lucene connector)** – named indexes via `luc:query` / `luc:entities`; list configured connectors with `?cntUri luc:listConnectors ?cntStr`.
+* **GraphDB (Elasticsearch connector)** – same pattern under the `elastic:` namespace.
+* **OpenLink Virtuoso** – [`bif:contains`](https://docs.openlinksw.com/virtuoso/bifcontainsoptions/), e.g. `?label bif:contains ?virtuosoQuery` (see [`?virtuosoQuery`](#writing-sparql-queries-for-a-source)).
+* **Wikidata** – the `wikibase:mwapi` service with `mwapi:search` (titles) or `mwapi:srsearch` (full text). See the [Wikidata MWAPI manual](https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual/MWAPI).

--- a/docs/services/network-of-terms/terminology-sources.md
+++ b/docs/services/network-of-terms/terminology-sources.md
@@ -17,7 +17,7 @@ Most importantly:
 * the source must be available as a SPARQL endpoint
 * basic information must be published for each term, at least a URI and a label. 
 
-If you’d like to add a source to the Network, please consult the [FAQ](https://termennetwerk.netwerkdigitaalerfgoed.nl/faq2).
+If you’d like to add a source to the Network, please consult the [FAQ](https://termennetwerk.netwerkdigitaalerfgoed.nl/faq2). The technical steps – dataset description, SPARQL search and lookup queries, and SHACL validation – live in the [catalog README](https://github.com/netwerk-digitaal-erfgoed/network-of-terms/blob/master/packages/catalog/README.md#adding-a-dataset).
 
 ## Writing SPARQL queries for a source
 


### PR DESCRIPTION
## Summary

- Document the `?query` / `?virtuosoQuery` template variables and `queryMode` in a new "Writing SPARQL queries for a source" section on the Terminology sources page.
- Rewrite the full-text search section with a per-backend recommendation (Fuseki, GraphDB Lucene plugin, Lucene/Elasticsearch connectors, Virtuoso, Wikidata MWAPI) and a clearer "prefer this over `FILTER CONTAINS`" line.
- Add a "Discover reconciliation endpoints" section to the GraphQL page and link to it from the Reconciliation page.
- Add a URI-prefix routing note under "Look up terms by URI".
- Add an OpenRefine usage section to the Reconciliation page that calls out the "Reconcile against no particular type" gotcha.
- Add a short orientation paragraph on the Network of Terms landing page explaining the split between this site (using the service) and the repo READMEs (running/hosting/extending). Mirror lives in [netwerk-digitaal-erfgoed/network-of-terms#…](https://github.com/netwerk-digitaal-erfgoed/network-of-terms).

Source for most of the added content is the [`network-of-terms-tutorial` wiki](https://github.com/netwerk-digitaal-erfgoed/network-of-terms-tutorial/wiki).

## Test plan

- [x] `npm run build` passes (en + nl locales)
- [ ] Spot-check the new sections in the rendered preview
