### PR TITLE
docs(dataset-register): document distribution health probes

### DIFF
--- a/docs/services/dataset-register/api.md
+++ b/docs/services/dataset-register/api.md
@@ -105,6 +105,12 @@ it flips to `false` on warnings and infos too, which is stricter than what the r
 For the exact JSON-LD and Turtle shapes of the report, see the `Valid` and `Invalid` response
 schemas in the OpenAPI spec.
 
+### Distribution-health probes
+
+During validation the Register also probes every distribution URL it can derive from the description (e.g. `dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and that the response matches the declared media type. On the API path a failed probe emits a `sh:Violation` — so an otherwise valid description can still be rejected with HTTP `400` if its distribution URLs are broken.
+
+Probe-emitted violations carry an `nde-probe:probeOutcome` IRI (`NetworkError`, `NotFound`, `ContentTypeMismatch`, …) on the `sh:ValidationResult`. The crawler keeps a longer-lived record of these outcomes per URL, queryable via the SPARQL endpoint — see [Distribution health](data-model.md#distribution-health) for the vocabulary and the named graph.
+
 ## Authentication
 
 Only `DELETE /datasets` requires authentication, via a Bearer token in the `Authorization`

--- a/docs/services/dataset-register/api.md
+++ b/docs/services/dataset-register/api.md
@@ -107,9 +107,7 @@ schemas in the OpenAPI spec.
 
 ### Distribution-health probes
 
-During validation the Register also probes every distribution URL it can derive from the description (e.g. `dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and that the response matches the declared media type. On the API path a failed probe emits a `sh:Violation` — so an otherwise valid description can still be rejected with HTTP `400` if its distribution URLs are broken.
-
-Probe-emitted violations carry an `nde-probe:probeOutcome` IRI (`NetworkError`, `NotFound`, `ContentTypeMismatch`, …) on the `sh:ValidationResult`. The crawler keeps a longer-lived record of these outcomes per URL, queryable via the SPARQL endpoint — see [Distribution health](data-model.md#distribution-health) for the vocabulary and the named graph.
+During validation the Register also probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and that the response matches the declared media type. A failed probe emits a `sh:Violation`, so a description that passes SHACL can still be rejected with HTTP `400` if one of its distribution URLs is broken. See [Distribution health](data-model.md#distribution-health) for the outcome vocabulary that appears on probe-emitted `sh:ValidationResult` nodes.
 
 ## Authentication
 

--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -160,7 +160,7 @@ For every distribution URL referenced by a registered dataset, the crawler perio
 https://datasetregister.netwerkdigitaalerfgoed.nl/sparql/distribution-health
 ```
 
-The graph is intentionally separate from the dataset graphs so it can be pruned or reset without touching the published DCAT. Each probed URL appears as a `nde-probe:DistributionHealthRecord` whose IRI **is** the distribution URL itself.
+Distribution health is **enrichment data produced by the register**, not metadata supplied by publishers. Keeping it in its own named graph makes that origin explicit — consumers can opt in or out of it cleanly, and the register can re-probe, prune, or reset the data without touching the published DCAT description in the dataset graphs. Each probed URL appears as a `nde-probe:DistributionHealthRecord` whose IRI **is** the distribution URL itself.
 
 Vocabulary prefix: `nde-probe: <https://def.nde.nl/probe#>`.
 

--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -152,6 +152,63 @@ how complete the description is. Reach it from a dataset via the `schema:content
 | [`schema:ratingValue`](https://schema.org/ratingValue)             | Rating for the dataset description.                       |
 | [`schema:ratingExplanation`](https://schema.org/ratingExplanation) | Explanation for the rating: which properties are missing? |
 
+### Distribution health
+
+For every distribution URL referenced by a registered dataset, the crawler periodically issues a probe (an HTTP `HEAD`/`GET` or a SPARQL `ASK`, depending on the distribution type) and records the outcome in a dedicated named graph:
+
+```text
+https://datasetregister.netwerkdigitaalerfgoed.nl/sparql/distribution-health
+```
+
+The graph is intentionally separate from the dataset graphs so it can be pruned or reset without touching the published DCAT. Each probed URL appears as a `nde-probe:DistributionHealthRecord` whose IRI **is** the distribution URL itself.
+
+Vocabulary prefix: `nde-probe: <https://def.nde.nl/probe#>`.
+
+| Property                       | Data type / notes                                                                                                                                                                              | Cardinality |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `nde-probe:lastProbedAt`       | `xsd:dateTime` — UTC timestamp of the most recent probe attempt.                                                                                                                                | 1..1        |
+| `nde-probe:lastOutcome`        | Outcome IRI of the last probe; absent when the last probe succeeded. One of the IRIs listed under [Probe outcomes](#probe-outcomes) below.                                                     | 0..1        |
+| `nde-probe:lastSuccessAt`      | `xsd:dateTime` — UTC timestamp of the most recent successful probe, if any.                                                                                                                     | 0..1        |
+| `nde-probe:firstFailureAt`     | `xsd:dateTime` — UTC timestamp at which the current failure streak began. Cleared on the next success.                                                                                          | 0..1        |
+| `nde-probe:consecutiveFailures`| `xsd:integer` — length of the current failure streak. Reset to `0` on the next success.                                                                                                         | 1..1        |
+
+#### Probe outcomes
+
+When a probe fails, `nde-probe:lastOutcome` is one of:
+
+| Outcome IRI                          | Meaning                                                                                       |
+| ------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `nde-probe:NetworkError`             | Connection refused, DNS failure, TLS error, timeout, or any other non-HTTP transport failure. |
+| `nde-probe:NotFound`                 | HTTP `404` or `410`.                                                                          |
+| `nde-probe:ServerError`              | HTTP `5xx`.                                                                                   |
+| `nde-probe:AuthRequired`             | HTTP `401` or `403`.                                                                          |
+| `nde-probe:RateLimited`              | HTTP `429`.                                                                                   |
+| `nde-probe:ContentTypeMismatch`      | Response was reachable but its `Content-Type` did not match the declared `dcat:mediaType` / `dct:format` / `schema:encodingFormat`. |
+| `nde-probe:ContentTypeMissing`       | Response had no `Content-Type` header at all.                                                 |
+| `nde-probe:EmptyBody`                | Response body was empty for a distribution that should have returned data.                    |
+| `nde-probe:SparqlProbeFailed`        | The distribution declares a SPARQL endpoint (`dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/>`) but the probe `ASK` query did not return a valid SPARQL result. |
+| `nde-probe:RdfParseFailed`           | The body was returned but could not be parsed as RDF.                                         |
+
+#### Effect on validation results
+
+Probe failures surface in the SHACL [validation report](api.md#validation-results) as additional `sh:ValidationResult` nodes, with one of two probe-specific constraint components on `sh:sourceConstraintComponent`:
+
+- `nde-probe:DistributionReachableConstraintComponent` — the URL itself could not be retrieved.
+- `nde-probe:DistributionFormatMatchConstraintComponent` — the URL was retrieved but the response did not match the declared media type / format.
+
+Probe-emitted results carry these extra properties beyond the standard SHACL ones:
+
+| Property                         | Description                                                                            |
+| -------------------------------- | -------------------------------------------------------------------------------------- |
+| `nde-probe:probeOutcome`         | One of the outcome IRIs in the table above.                                            |
+| `nde-probe:firstFailureAt`       | `xsd:dateTime` — copied from the health record, so consumers see how long the URL has been failing without joining the health graph. Present only on crawler-emitted results. |
+| `nde-probe:consecutiveFailures`  | `xsd:integer` — length of the current failure streak. Present only on crawler-emitted results. |
+
+The REST API and the crawler differ in how strict they are about probe failures:
+
+- **REST API** (`POST /datasets`, `POST/PUT /datasets/validate`): any failed probe is emitted at `sh:Violation` immediately. A registration with a broken distribution URL is rejected synchronously with HTTP `400`.
+- **Crawler**: probes run every crawl round but are only promoted to `sh:Violation` once `nde-probe:firstFailureAt` is older than the failure-streak threshold (default 7 days). Transient blips do not flip a dataset to invalid.
+
 ## Allow list
 
 A registration URL must be on a domain that is allowed before it can be added to the Register.

--- a/docs/services/dataset-register/sparql.md
+++ b/docs/services/dataset-register/sparql.md
@@ -48,6 +48,7 @@ you can query; jump straight to the section you need:
 - [Dataset](data-model.md#dataset): `dcat:Dataset`, `dcat:Distribution`, `foaf:Agent`
 - [Registration](data-model.md#registration): the register-specific metadata used for
   [registration status](#registration-status) below
+- [Distribution health](data-model.md#distribution-health): per-URL probe results (reachability and content-type match), exposed in a dedicated named graph
 - [Allow list](data-model.md#allow-list): which domains are permitted to register datasets
 
 ## Registration status


### PR DESCRIPTION
Documents the distribution-health probes that the Dataset Register now runs against every distribution URL (shipped via netwerk-digitaal-erfgoed/dataset-register#1919).

## Changes

- **`data-model.md`** — new **Distribution health** section under Registration:
  - explains that the data is register-generated enrichment, kept in its own named graph (`…/sparql/distribution-health`) so consumers can opt in or out without touching publisher-supplied DCAT
  - the `nde-probe:DistributionHealthRecord` properties (`lastProbedAt`, `lastOutcome`, `lastSuccessAt`, `firstFailureAt`, `consecutiveFailures`)
  - the failure-outcome IRIs (`NetworkError`, `NotFound`, `ContentTypeMismatch`, …)
  - the two probe-specific SHACL constraint components and the extra properties carried on probe-emitted `sh:ValidationResult`s
  - the strict API vs. lenient crawler promotion behaviour (default 7-day streak threshold)
- **`api.md`** — short note under Validation results: a SHACL-valid description can still come back HTTP `400` if a distribution probe fails, with a link through to the vocabulary.
- **`sparql.md`** — Distribution health added to the data-model jump list.

Builds locally for both `en` and `nl` locales.
