### PR TITLE
docs(dataset-register): use https://schema.org/ in SPARQL example

### DIFF
--- a/docs/services/dataset-register/sparql.md
+++ b/docs/services/dataset-register/sparql.md
@@ -67,7 +67,7 @@ and the registration URL carries a `schema:additionalType` flag indicating its c
 
 ```sparql
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX schema: <http://schema.org/>
+PREFIX schema: <https://schema.org/>
 SELECT * {
   ?dataset a dcat:Dataset ;
     schema:subjectOf ?registrationUrl .


### PR DESCRIPTION
The dataset-register normalizes `http://schema.org/` to `https://schema.org/` at ingest via `StandardizeSchemaOrgPrefixToHttps` (`packages/core/src/transform.ts:14`), so the example query with the `http://` prefix returns zero results against the production endpoint. Surfaced while investigating SCHEMA-AP-NDE conformance numbers — operators copying the docs example were silently getting empty results.