### PR TITLE
fix(css): keep external-link arrow on the same line as the link text

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -108,7 +108,7 @@ a[target="_blank"] > svg[class*="iconExternalLink"] {
 .markdown a[target="_blank"]::after,
 .footer__link-item[target="_blank"]::after,
 .navbar__link[target="_blank"]::after {
-  content: " \2197";
+  content: "\00a0\2197";
 }
 
 .pagination-nav__link {


### PR DESCRIPTION
Replace the regular space before the `↗` arrow in the external-link `::after` content with a non-breaking space (`\00a0`), so the arrow stays attached to the link’s last word and no longer wraps onto its own line.
