### PR TITLE
fix: set explicit description on SCHEMA-AP-NDE 1.0 post

### DIFF
--- a/blog/2026-06-01-schema-ap-nde-1.0.md
+++ b/blog/2026-06-01-schema-ap-nde-1.0.md
@@ -2,6 +2,7 @@
 title: NDE releases SCHEMA-AP-NDE 1.0
 authors: [ddeboer]
 tags: [rdf, requirements]
+description: "NDE releases SCHEMA-AP-NDE 1.0: the first stable version of the Schema.org Application Profile for the Dutch cultural heritage network, with a backward compatibility promise for everything on 1.x."
 ---
 
 Today NDE releases **[SCHEMA-AP-NDE](https://docs.nde.nl/schema-profile/) 1.0**: the first stable version of the Schema.org Application Profile every dataset in the Dutch cultural heritage network is expected to publish. It comes with a **backward compatibility promise**: as long as we stay on 1.x, data that conforms keeps conforming, and software built against it keeps working.


### PR DESCRIPTION
## What

Set an explicit `description` in the front matter of the **NDE releases SCHEMA-AP-NDE 1.0** blog post.

## Why

Docusaurus auto-generates the page’s `<meta name="description">` / `og:description` from the first paragraph. That paragraph opens with inline markdown — a bold-with-link (`**[SCHEMA-AP-NDE](…) 1.0**`) and a bold span (`**backward compatibility promise**`) — which the auto-generator chokes on, dropping the plain text between them. The result was a garbled link-preview summary:

> Today NDE releases SCHEMA-AP-NDE 1.0 as long as we stay on 1.x, data that conforms keeps conforming, and software built against it keeps working.

## How

- Add a front matter `description` so Docusaurus emits it verbatim as `<meta name="description">` and `og:description`.
- The post body is unchanged — it keeps its bold; only the meta description is overridden. The visible blog-list excerpt (which renders the truncated content, not the description) is likewise unaffected.
