### PR TITLE
docs(dataset-register): clarify strict API vs lenient crawler probe behaviour

### DIFF
--- a/docs/services/dataset-register/api.md
+++ b/docs/services/dataset-register/api.md
@@ -107,7 +107,7 @@ schemas in the OpenAPI spec.
 
 ### Distribution-health probes
 
-During validation the Register also probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and that the response matches the declared media type. A failed probe emits a `sh:Violation`, so a description that passes SHACL can still be rejected with HTTP `400` if one of its distribution URLs is broken. See [Distribution health](data-model.md#distribution-health) for the outcome vocabulary that appears on probe-emitted `sh:ValidationResult` nodes.
+During validation the Register also probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and serves the declared media type. Even when the description passes SHACL, a broken or mistyped distribution URL is reported as a `sh:Violation` and rejected with HTTP `400` — so fix the URL before (re)submitting. After a dataset is registered the crawler re-checks the same URLs more leniently; see [Distribution health](data-model.md#distribution-health) for that behaviour, the [outcome vocabulary](data-model.md#probe-outcomes), and how failures [appear in the report](data-model.md#effect-on-validation-results).
 
 ## Authentication
 

--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -195,7 +195,7 @@ When a probe fails, `nde-probe:lastOutcome` is one of:
 
 ### Effect on validation results
 
-Probe failures surface in the SHACL [validation report](api.md#validation-results) as additional `sh:ValidationResult` nodes, with one of two probe-specific constraint components on `sh:sourceConstraintComponent`:
+Probe failures surface in the SHACL [validation report](api.md#validation-results) — see also the REST API's [distribution-health probes](api.md#distribution-health-probes) — as additional `sh:ValidationResult` nodes, with one of two probe-specific constraint components on `sh:sourceConstraintComponent`:
 
 - `nde-probe:DistributionReachableConstraintComponent` — the URL itself could not be retrieved.
 - `nde-probe:DistributionFormatMatchConstraintComponent` — the URL was retrieved but the response did not match the declared media type / format.
@@ -210,8 +210,13 @@ Probe-emitted results carry these extra properties beyond the standard SHACL one
 
 The REST API and the crawler differ in how strict they are about probe failures:
 
-- **REST API** (`POST /datasets`, `POST/PUT /datasets/validate`): any failed probe is emitted at `sh:Violation` immediately. A registration with a broken distribution URL is rejected synchronously with HTTP `400`.
-- **Crawler**: probes run every crawl round but are only promoted to `sh:Violation` once `nde-probe:firstFailureAt` is older than the failure-streak threshold (default 7 days). Transient blips do not flip a dataset to invalid.
+| Caller | Probe-failure severity | Effect |
+| ------ | ---------------------- | ------ |
+| **Registration** (`POST /datasets`) | `sh:Violation` (strict) | A faulty distribution makes the dataset invalid, so it is rejected with HTTP `400` and never indexed. |
+| **Validation** (`POST`/`PUT /datasets/validate`) | `sh:Violation` (strict) | The same result registration would give – an accurate dry-run; the [validate page](https://datasetregister.netwerkdigitaalerfgoed.nl/validate) shows the dataset as invalid. |
+| **Crawler** | declared `sh:severity` (`sh:Warning` today) | Emitted only once the failure streak is persistent (`nde-probe:firstFailureAt` older than the threshold, default 7 days); a distribution that breaks *after* registration is flagged without invalidating the dataset, and transient blips are suppressed. |
+
+The REST API is strict regardless of the severity the shapes declare, so it will not admit a dataset whose distributions are unreachable or mistyped at submit time. The crawler instead honours the shapes: promoting `nde-probe:probeReachable` / `nde-probe:probeFormatMatch` to `sh:Violation` in the [Requirements for Datasets](https://docs.nde.nl/requirements-datasets/) would make the crawler invalidate matching datasets too.
 
 ## Allow list
 


### PR DESCRIPTION
Mirrors the behaviour change in dataset-register [PR #2015](https://github.com/netwerk-digitaal-erfgoed/dataset-register/pull/2015), where the distribution probe now emits failures at the `sh:severity` declared in the shapes, but only the crawler honours that.

Updates the dataset-register docs so the strict-API / lenient-crawler split is accurate:

- **`data-model.md`** (Distribution health → Effect on validation results): the crawler emits failures at the shapes' declared severity (`sh:Warning` today) once the streak is persistent, rather than promoting to `sh:Violation`; the REST API stays strict for both registration and the `/validate` endpoints.
- **`api.md`** (Distribution-health probes): the REST API emits probe failures at `sh:Violation` even though the shapes are declared `sh:Warning`, and notes the crawler is the lenient counterpart.

Prose-only; `npm run build` passes (pre-existing broken anchors are confined to unrelated `/nl/stack/` pages).
