### PR TITLE
docs(dataset-register): add a dedicated Validation chapter

### DIFF
--- a/docs/services/dataset-register/api.md
+++ b/docs/services/dataset-register/api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # REST API
@@ -50,64 +50,9 @@ endpoints are normally used in this order:
 for example in a CI pipeline or an authoring tool that highlights violations inline. The shape
 graph returned here is the authoritative source: it matches what the validation endpoints apply.
 
-## Validation results
+## Validation
 
-Validation is performed against the
-[Requirements for Datasets](https://docs.nde.nl/requirements-datasets/), expressed as the SHACL
-shape graph available from `GET /shacl`. How you interpret the result depends on whether you
-call the API or run the shape graph yourself.
-
-:::tip
-
-If you only need to check a single dataset description by hand – e.g. to confirm a publisher’s
-URL before integrating – use the public
-[validation web service](https://datasetregister.netwerkdigitaalerfgoed.nl/validate). It runs
-the same SHACL shape as the API.
-
-:::
-
-### Calling the API
-
-The **HTTP status code is the authoritative signal**; you do not need to parse the SHACL report to decide pass or fail:
-
-| Status | Meaning                                                                    |
-|--------|----------------------------------------------------------------------------|
-| `200`  | Valid. Returned by `POST /datasets/validate` and `PUT /datasets/validate`. |
-| `202`  | Valid; queued for ingestion. Returned by `POST /datasets`.                 |
-| `400`  | Invalid – one or more SHACL violations. The response body lists them.      |
-
-The status maps to **validity**, not to SHACL's `sh:conforms`. A description is considered *valid* when no
-result has severity `sh:Violation`; warnings and infos do not block ingestion. 
-SHACL’s `sh:conforms` is stricter: it is only `true` when there are no violations _and_ no warnings _and_ no infos.
-So a `200` or `202` response can still carry a report with `sh:conforms = false` if the description triggered warnings or infos.
-
-In short: use the status code to keep or reject; surface anything else in the report body to
-the editor as advisory feedback.
-
-### Validating against the SHACL shape directly
-
-If you fetch the shape graph from `GET /shacl` and run validation in your own pipeline (e.g.
-an authoring tool that highlights violations inline, or a CI check on a publishing repo),
-there is no HTTP status to lean on; only the SHACL [validation report](https://www.w3.org/TR/shacl/#validation-report). 
-Walk every `sh:ValidationResult` and inspect its `sh:resultSeverity`:
-
-| Severity       | Meaning                                                                                   |
-|----------------|-------------------------------------------------------------------------------------------|
-| `sh:Violation` | The register would reject this description (HTTP `400`). Must be fixed before submitting. |
-| `sh:Warning`   | The register would accept the description now, but reject it in the future.               |
-| `sh:Info`      | Suggestions.                                                                              |
-
-To reproduce the register’s accept/reject decision, treat the description as valid when no
-result has severity `sh:Violation`. 
-Do _not_ rely on `sh:conforms` for this decision:
-it flips to `false` on warnings and infos too, which is stricter than what the register enforces.
-
-For the exact JSON-LD and Turtle shapes of the report, see the `Valid` and `Invalid` response
-schemas in the OpenAPI spec.
-
-### Distribution-health probes
-
-During validation the Register also probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and serves the declared media type. Even when the description passes SHACL, a broken or mistyped distribution URL is reported as a `sh:Violation` and rejected with HTTP `400` — so fix the URL before (re)submitting. After a dataset is registered the crawler re-checks the same URLs more leniently; see [Distribution health](data-model.md#distribution-health) for that behaviour, the [outcome vocabulary](data-model.md#probe-outcomes), and how failures [appear in the report](data-model.md#effect-on-validation-results).
+The Register validates every description you submit. The **HTTP status code is authoritative**: `200`/`202` mean valid (accepted) and `400` means invalid (rejected, with the SHACL report in the body). See the [Validation](validation.md) chapter for how to read the report, the severity semantics, validating the shape graph yourself, and the distribution-health probes that can reject an otherwise-valid description.
 
 ## Authentication
 

--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 5
 description: The DCAT-AP-NL data model that the Dataset Register exposes to consumers.
 ---
 
@@ -195,28 +195,7 @@ When a probe fails, `nde-probe:lastOutcome` is one of:
 
 ### Effect on validation results
 
-Probe failures surface in the SHACL [validation report](api.md#validation-results) — see also the REST API's [distribution-health probes](api.md#distribution-health-probes) — as additional `sh:ValidationResult` nodes, with one of two probe-specific constraint components on `sh:sourceConstraintComponent`:
-
-- `nde-probe:DistributionReachableConstraintComponent` — the URL itself could not be retrieved.
-- `nde-probe:DistributionFormatMatchConstraintComponent` — the URL was retrieved but the response did not match the declared media type / format.
-
-Probe-emitted results carry these extra properties beyond the standard SHACL ones:
-
-| Property                         | Description                                                                            |
-| -------------------------------- | -------------------------------------------------------------------------------------- |
-| `nde-probe:probeOutcome`         | One of the outcome IRIs in the table above.                                            |
-| `nde-probe:firstFailureAt`       | `xsd:dateTime` — copied from the health record, so consumers see how long the URL has been failing without joining the health graph. Present only on crawler-emitted results. |
-| `nde-probe:consecutiveFailures`  | `xsd:integer` — length of the current failure streak. Present only on crawler-emitted results. |
-
-The REST API and the crawler differ in how strict they are about probe failures:
-
-| Caller | Probe-failure severity | Effect |
-| ------ | ---------------------- | ------ |
-| **Registration** (`POST /datasets`) | `sh:Violation` (strict) | A faulty distribution makes the dataset invalid, so it is rejected with HTTP `400` and never indexed. |
-| **Validation** (`POST`/`PUT /datasets/validate`) | `sh:Violation` (strict) | The same result registration would give – an accurate dry-run; the [validate page](https://datasetregister.netwerkdigitaalerfgoed.nl/validate) shows the dataset as invalid. |
-| **Crawler** | declared `sh:severity` (`sh:Warning` today) | Emitted only once the failure streak is persistent (`nde-probe:firstFailureAt` older than the threshold, default 7 days); a distribution that breaks *after* registration is flagged without invalidating the dataset, and transient blips are suppressed. |
-
-The REST API is strict regardless of the severity the shapes declare, so it will not admit a dataset whose distributions are unreachable or mistyped at submit time. The crawler instead honours the shapes: promoting `nde-probe:probeReachable` / `nde-probe:probeFormatMatch` to `sh:Violation` in the [Requirements for Datasets](https://docs.nde.nl/requirements-datasets/) would make the crawler invalidate matching datasets too.
+Probe failures also surface in the SHACL validation report as `sh:ValidationResult` nodes. See [Validation: how probe failures appear in the report](validation.md#how-probe-failures-appear-in-the-report) for the constraint components, the extra properties they carry, and how strict each caller (registration, validation, crawler) is.
 
 ## Allow list
 

--- a/docs/services/dataset-register/index.md
+++ b/docs/services/dataset-register/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Dataset Register
@@ -14,7 +14,7 @@ that includes:
 
 ## Where to go next
 
-**If you are publishing a dataset**, register your dataset description via the [REST API](api.md). The Register fetches it, validates it against the [Requirements for Datasets](https://docs.nde.nl/requirements-datasets/), and stores the result. See also [Register your dataset](../../publish/register.md) for the publisher-side walkthrough.
+**If you are publishing a dataset**, register your dataset description via the [REST API](api.md). The Register fetches it, [validates](validation.md) it against the [Requirements for Datasets](https://docs.nde.nl/requirements-datasets/), and stores the result. See also [Register your dataset](../../publish/register.md) for the publisher-side walkthrough.
 
 **If you are consuming the Register**, query the [SPARQL endpoint](sparql.md). The [data model](data-model.md) describes the DCAT-AP-NL shapes you will encounter in the results.
 

--- a/docs/services/dataset-register/sparql.md
+++ b/docs/services/dataset-register/sparql.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 ---
 
 # SPARQL API

--- a/docs/services/dataset-register/validation.md
+++ b/docs/services/dataset-register/validation.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 3
+---
+
+# Validation
+
+The Dataset Register validates every description it receives – both when you submit it through
+the [REST API](api.md) and when the crawler re-fetches a registered URL. This chapter explains
+what is checked, how to read the result, and why a description might be rejected. It is relevant
+to **publishers** confirming their descriptions and to **software developers** building
+validation into their tooling.
+
+Validation runs against the
+[Requirements for Datasets](https://docs.nde.nl/requirements-datasets/), expressed as the SHACL
+shape graph available from `GET /shacl`. How you interpret the result depends on whether you call
+the API or run the shape graph yourself.
+
+:::tip
+
+If you only need to check a single dataset description by hand – e.g. to confirm a publisher’s
+URL before integrating – use the public
+[validation web service](https://datasetregister.netwerkdigitaalerfgoed.nl/validate). It runs
+the same SHACL shape as the API.
+
+:::
+
+## Calling the API
+
+The **HTTP status code is the authoritative signal**; you do not need to parse the SHACL report to decide pass or fail:
+
+| Status | Meaning                                                                    |
+|--------|----------------------------------------------------------------------------|
+| `200`  | Valid. Returned by `POST /datasets/validate` and `PUT /datasets/validate`. |
+| `202`  | Valid; queued for ingestion. Returned by `POST /datasets`.                 |
+| `400`  | Invalid – one or more SHACL violations. The response body lists them.      |
+
+The status maps to **validity**, not to SHACL's `sh:conforms`. A description is considered *valid* when no
+result has severity `sh:Violation`; warnings and infos do not block ingestion.
+SHACL’s `sh:conforms` is stricter: it is only `true` when there are no violations _and_ no warnings _and_ no infos.
+So a `200` or `202` response can still carry a report with `sh:conforms = false` if the description triggered warnings or infos.
+
+In short: use the status code to keep or reject; surface anything else in the report body to
+the editor as advisory feedback.
+
+## Validating against the SHACL shape directly
+
+If you fetch the shape graph from `GET /shacl` and run validation in your own pipeline (e.g.
+an authoring tool that highlights violations inline, or a CI check on a publishing repo),
+there is no HTTP status to lean on; only the SHACL [validation report](https://www.w3.org/TR/shacl/#validation-report).
+Walk every `sh:ValidationResult` and inspect its `sh:resultSeverity`:
+
+| Severity       | Meaning                                                                                   |
+|----------------|-------------------------------------------------------------------------------------------|
+| `sh:Violation` | The register would reject this description (HTTP `400`). Must be fixed before submitting. |
+| `sh:Warning`   | The register would accept the description now, but reject it in the future.               |
+| `sh:Info`      | Suggestions.                                                                              |
+
+To reproduce the register’s accept/reject decision, treat the description as valid when no
+result has severity `sh:Violation`.
+Do _not_ rely on `sh:conforms` for this decision:
+it flips to `false` on warnings and infos too, which is stricter than what the register enforces.
+
+For the exact JSON-LD and Turtle shapes of the report, see the `Valid` and `Invalid` response
+schemas in the [OpenAPI specification](https://datasetregister.netwerkdigitaalerfgoed.nl/api/).
+
+## Distribution-health probes
+
+During validation the Register also probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and serves the declared media type. Even when the description passes SHACL, a broken or mistyped distribution URL is reported as a `sh:Violation` and rejected with HTTP `400` — so fix the URL before (re)submitting.
+
+The REST API and the crawler differ in how strict they are about probe failures:
+
+| Caller | Probe-failure severity | Effect |
+| ------ | ---------------------- | ------ |
+| **Registration** (`POST /datasets`) | `sh:Violation` (strict) | A faulty distribution makes the dataset invalid, so it is rejected with HTTP `400` and never indexed. |
+| **Validation** (`POST`/`PUT /datasets/validate`) | `sh:Violation` (strict) | The same result registration would give – an accurate dry-run; the [validate page](https://datasetregister.netwerkdigitaalerfgoed.nl/validate) shows the dataset as invalid. |
+| **Crawler** | declared `sh:severity` (`sh:Warning` today) | Emitted only once the failure streak is persistent (`nde-probe:firstFailureAt` older than the threshold, default 7 days); a distribution that breaks *after* registration is flagged without invalidating the dataset, and transient blips are suppressed. |
+
+The REST API is strict regardless of the severity the shapes declare, so it will not admit a dataset whose distributions are unreachable or mistyped at submit time. The crawler instead honours the shapes: promoting `nde-probe:probeReachable` / `nde-probe:probeFormatMatch` to `sh:Violation` in the [Requirements for Datasets](https://docs.nde.nl/requirements-datasets/) would make the crawler invalidate matching datasets too.
+
+### How probe failures appear in the report
+
+Probe failures surface in the validation report as additional `sh:ValidationResult` nodes, with one of two probe-specific constraint components on `sh:sourceConstraintComponent`:
+
+- `nde-probe:DistributionReachableConstraintComponent` — the URL itself could not be retrieved.
+- `nde-probe:DistributionFormatMatchConstraintComponent` — the URL was retrieved but the response did not match the declared media type / format.
+
+Probe-emitted results carry these extra properties beyond the standard SHACL ones:
+
+| Property                         | Description                                                                            |
+| -------------------------------- | -------------------------------------------------------------------------------------- |
+| `nde-probe:probeOutcome`         | One of the [outcome IRIs](data-model.md#probe-outcomes).                               |
+| `nde-probe:firstFailureAt`       | `xsd:dateTime` — copied from the health record, so consumers see how long the URL has been failing without joining the health graph. Present only on crawler-emitted results. |
+| `nde-probe:consecutiveFailures`  | `xsd:integer` — length of the current failure streak. Present only on crawler-emitted results. |
+
+Every probe the crawler runs — successful or not — is also recorded as queryable enrichment data. See [Distribution health](data-model.md#distribution-health) in the data model for that named graph, the [`nde-probe:DistributionHealthRecord`](data-model.md#nde-probedistributionhealthrecord) structure, and the [outcome vocabulary](data-model.md#probe-outcomes).


### PR DESCRIPTION
Follow-up to #90 (now merged). Validation was spread across two pages — the [REST API](https://docs.nde.nl/services/dataset-register/api/) page (status codes, severity semantics, distribution probes) and the [Data model](https://docs.nde.nl/services/dataset-register/data-model/) page (effect on validation results). This consolidates it into one publisher-facing chapter.

- **`validation.md`** (new): how validation works (SHACL + Requirements), calling the API (status codes, severity → accept/reject), validating the SHACL shape yourself, distribution-health probes (strict at the API, lenient at crawl, with the Caller × severity × effect table), and how probe failures appear in the report.
- **`api.md`**: the `## Validation results` section becomes a short pointer to the chapter; the endpoint reference stays.
- **`data-model.md`**: `### Effect on validation results` becomes a pointer; the queryable `nde-probe:DistributionHealthRecord` graph and outcome vocabulary stay (they belong in the data model).
- **`index.md`**: the overview links "validates" to the new chapter.
- Sidebar renumbered (autogenerated from the folder) so **Validation** follows the overview.

Prose-only; `npm run build` passes. The only broken-anchor warnings are pre-existing and confined to unrelated `/stack/` pages; no links point at the moved `api.md` anchors.
