### PR TITLE
docs(stack): add Stack chapter

### DIFF
--- a/docs/stack/index.md
+++ b/docs/stack/index.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 8
+---
+
+# Stack
+
+:::warning Draft – under review
+This chapter proposes engineering choices, naming conventions, and operational patterns for the NDE network which are not yet endorsed by NDE. Feedback welcome via the [issue tracker](https://github.com/netwerk-digitaal-erfgoed/docs/issues).
+:::
+
+## Introduction
+
+The **NDE Stack** is the working name given here to the **ecosystem of [NDE-compatible](../glossary.md#nde-compatible) [components](#components)** and the **[operational patterns](patterns.md)** that compose them, grounded in the network’s shared standards.
+The Stack’s goal is to **help software developers in the NDE network solve shared functionality once** rather than reinventing it in each project.
+Most of what appears here is new: proposed components and patterns yet to be built.
+The rest is existing software given a role in the Stack.
+
+The Stack **operationalises the architecture** sketched in [*Van data naar dienst: visie op de ontwikkeling van verbonden erfgoeddiensten*](https://zenodo.org/records/17541400) (NDE, November 2025), covering the [Data and Presentation Layers](layers/platform.md) of a [Service Platform](../glossary.md#service-platform). The Stack also includes the [Publication Layer](layers/provider.md#publication-layer) and connects to source-side data management. As more of the network’s functionality is named, the Stack grows. Where the report leaves gaps, the Stack fills them.
+
+These chapters are also meant to **create a shared language and understanding** across the network:
+a [common vocabulary](#taxonomy) for the components, patterns, and operational mechanics that builders, operators, and decision-makers can use when discussing what the Stack does and how it fits together.
+Naming the parts is the prerequisite for talking about them coherently across teams and organisations.
+
+## Scope
+
+**This is**: a bridge from the report’s architectural vocabulary to running code. Names concrete components (existing and proposed), default operational patterns, and the foundational technologies the Stack depends on.
+
+**This isn’t**: a restatement of the report. The report describes *what* should happen at each step of a [Service Platform](../glossary.md#service-platform); this guidance proposes *how*, at the engineering level, with named patterns and packages.
+
+**Goes beyond the report where useful**: some practical engineering concerns are not in the report, such as semantic search, snapshot-CDC (change data capture) deletion handling, per-source outage resilience, declarative standards-backed pipeline configuration. The Stack picks these up as natural extensions of the report’s framework, flagged in context where they appear so a reader can tell report-grounded content from Stack-direction extensions.
+
+**Primary audience**: builders of [Service Platforms](../glossary.md#service-platform) and [network services](../services/index.md) within the NDE network.
+
+**Status of contents**: many components are proposals (`@lde/*` or `@ndes/*` packages that do not exist yet). The [function-mapping table](layers/platform.md#function-mapping) marks them as such. Patterns labelled “Proposed” have been discussed but not endorsed.
+
+## Taxonomy
+
+The Stack uses a small vocabulary consistently.
+
+| Term | Definition | Examples                                                                                                                                                              |
+| --- | --- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Component** | Software the Stack provides | `@lde/*` packages, `@ndes/*` packages                                                                                                                                 |
+| **Pattern** | Operational mechanic | [Blue/green Rebuild](patterns.md#bluegreen-rebuild), [SCHEMA-AP-NDE-first](patterns.md#schema-ap-nde-first), [Ports & Adapters](patterns.md#adapters)                        |
+| **Service** | A running instance of a Component, deployed with a specific configuration | A [Service Platform](../glossary.md#service-platform) running the search projection with its own SHACL and search configuration                                       |
+| **Network service** | A Service operated by NDE, network-wide, addressable as a single canonical endpoint | [Dataset Register](../services/dataset-register/), [Network of Terms](../services/network-of-terms/), [Dataset Knowledge Graph](../services/dataset-knowledge-graph/) |
+| **Standard** | A network commitment the Stack adopts | SCHEMA-AP-NDE, LDES, IIIF, DCAT-AP 3.0 / Schema.org Dataset                                                                                                        |
+| **Foundational technology** | Upstream open-source dependency outside NDE governance | QLever, Typesense, nginx, Fastify, Mercurius                                                                                                                          |
+
+## Components
+
+The Stack provides the components below. They live in the [Service Platform side](layers/platform.md) chapter; this catalog is a quick index. The [Pipeline](pipeline.md) chapter shows how the pipeline components compose.
+
+| Component | Layer | Brief |
+| --- | --- | --- |
+| **[Search Pipeline](layers/platform.md#search-pipeline)** *(proposed)* | Data | Builds a search index of records from selected datasets |
+| **[Knowledge Graph Pipeline](layers/platform.md#knowledge-graph-pipeline)** | Data | Builds a queryable knowledge graph from selected datasets |
+| **[Search APIs](layers/platform.md#search-apis)** *(proposed)* | Data | Search and filter API that Presentation Layers consume |
+| **[Knowledge Graph APIs](layers/platform.md#knowledge-graph-apis)** | Data | Query interfaces for the Stack’s knowledge graphs: [DKG](../services/dataset-knowledge-graph/) *(operational)*, Term Backlink Graph *(proposed)*, Knowledge Graph voor Termen *(proposed)*, and any self-operated KG a Service Platform builds |
+| **[Change Stream Producer](layers/platform.md#change-stream-producer)** *(proposed)* | Data | Publishes a Service Platform’s data changes as a feed other systems can subscribe to |
+| **[Heritage UI Components](layers/platform.md#presentation-layer)** *(future)* | Presentation | Reusable display components |
+
+## Foundational technologies
+
+The Stack is built on top of mature open-source infrastructure that lives outside NDE/LDE governance. These are **dependencies, not Stack components**; release cycles, roadmaps, and breaking changes follow upstream projects. The Stack picks opinionated defaults and treats them as exchangeable for any conformant alternative; substitutes plug in behind ports defined by the [Ports & adapters pattern](patterns.md#adapters), so a swap is a configuration concern rather than a code rewrite.
+
+| Concern                         | Stack default                                                                                                                        | Realistic substitutes                                                                              |
+|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| [RDF](../glossary.md#rdf) triplestore / SPARQL engine | [QLever](https://github.com/ad-freiburg/qlever) – read-only-after-load, fast bulk-load, fits blue/green rebuild                      | [Oxigraph](https://github.com/oxigraph/oxigraph), GraphDB, Jena Fuseki                             |
+| Search engine                   | [Typesense](https://typesense.org/) – used by the search pipeline                                                                    | Elasticsearch, OpenSearch (each behind their own adapter at the search pipeline’s engine boundary) |
+| Reverse proxy                   | nginx – default for proxy-level [blue/green](patterns.md#bluegreen-rebuild)                                                          | HAProxy (runtime API for zero-reload switching), Caddy (admin-API hot reload), Envoy               |
+| Web / API runtime               | [Fastify](https://fastify.dev/) + [Mercurius](https://mercurius.dev/) – the GraphQL stack used by the proposed `@lde/graphql-server` | Apollo Server, Yoga, any GraphQL.js-based runtime                                                  |
+
+## Substrates
+
+Three distinct bodies of source data (substrates) underlie the Stack. Each pipeline rides on exactly one. They differ in source, scale, cadence, and consumers; the layer pages refer back to them by letter.
+
+| Substrate | What’s crawled                                                                                  | Source(s) | Scale / cadence                                              | Feeds                                                                                                                                                         |
+| --- |-------------------------------------------------------------------------------------------------| --- |--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| A. [Dataset descriptions](../glossary.md#dataset-description) | DCAT-AP metadata *about* datasets (titles, publishers, [distributions](../glossary.md#distribution), licenses, subjects)       | Publishers’ DCAT-AP descriptions, harvested by the [NDE Datasetregister](https://datasetregister.netwerkdigitaalerfgoed.nl/) | Small, metadata-only. Refresh frequently (daily)             | Enumeration for B: which datasets exist and where their distributions live                                                                                    |
+| B. Dataset contents | Heritage records *inside* each distribution (instances of `CreativeWork`, `Person`, `Place`, …) | Per-dataset SPARQL endpoint or RDF dump | Large, per-dataset. Refresh per source on last modified date | [Search Pipeline](layers/platform#search-pipeline); [Dataset Knowledge Graph](../services/dataset-knowledge-graph/); Term Backlink Graph (data-model-agnostic vocab walk) |
+| C. [Terminology sources](../glossary.md#terminology-source) | Term-to-term relations across terminology sources                                               | Terminology sources, aggregated by the [NDE Network of Terms](https://termennetwerk.netwerkdigitaalerfgoed.nl/) | Medium, vocabulary-scoped. Refresh on vocab updates          | The report’s “Knowledge Graph voor Termen” (function 5)                                                                                                       |
+
+Observations that fall out of this separation:
+
+- **A enumerates B, not C.** B’s pipelines read the Register to learn which datasets exist and where their distributions live. C is enumerated separately, from the [Network of Terms](../services/network-of-terms/) catalogue of terminology sources. Part of that catalogue may migrate into the Register over time, but external sources like GeoNames, AAT and Wikidata stay outside it, so C keeps its own enumeration.
+- **B carries multiple projections.** The same crawl feeds three structurally different sinks: an AP-aware search-document projection ([Search Pipeline](layers/platform#search-pipeline)), a [VoID](https://www.w3.org/TR/void/) (Vocabulary of Interlinked Datasets) statistical summary ([Dataset Knowledge Graph](../services/dataset-knowledge-graph/)), and a data-model-agnostic term-backlink projection (Term Backlink Graph). All three are enumerated from A but compute over B’s contents: what differs is the projection, not the substrate.
+- **Change cadences differ.** B changes most often: records are added, updated, and removed at source as collections grow. A changes less often: dataset metadata is updated more rarely than the records it describes. C is most stable: vocabularies move slowly. Stack components inherit the change cadence of the substrate they ride on.

--- a/docs/stack/layers/index.md
+++ b/docs/stack/layers/index.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 1
+---
+
+# Layers
+
+:::warning Draft – under review
+Part of the Stack documentation ([overview](../index.md)). Not yet endorsed by NDE.
+:::
+
+The NDE network architecture distinguishes four layers. This chapter consolidates per-layer Stack guidance: each layer’s patterns, standards, and components. Bottom-up:
+
+| Layer | Scope                                                                                                                                                                               | Who runs it |
+| --- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- |
+| Data management | Source-internal handling: collection management systems, internal catalogues, cleanup at source. Out of scope for this Stack documentation; see [Requirements](../../requirements). | [Data Provider](../../glossary.md#data-provider) |
+| [Publication](#publication) | Source-side externalisation: RDF dump, SPARQL endpoint, IIIF, LDES.                                                                                                                 | [Data Provider](../../glossary.md#data-provider) |
+| [Data Layer](#data-layer) | Service Platform internals.                                                                                                                                                         | [Service Platform](../../glossary.md#service-platform) |
+| [Presentation Layer](#presentation-layer) | User-facing presentation.                                                                                                                                                           | [Service Platform](../../glossary.md#service-platform) / [consumer](../../glossary.md#consumer) application |
+
+The [NDE Stack](../) covers all four layers. It is positioned around the full Linked Data lifecycle the same way Linked Data Elements ([LDE](https://github.com/ldelements/lde)) is (Discovery / Ingestion / Transformation / Analysis / Publication / Serve).
+LDE is a toolkit of small, composable `@lde/*` packages that handle generic linked-data plumbing:
+discovering datasets, downloading distributions, running pipelines, serving SPARQL and RDF. It is data-model-agnostic and network-agnostic.
+The NDE Stack composes LDE’s packages with NDE-specific configuration (`@ndes/*`) and operated [network services](../../services/) to produce the NDE approach of the lifecycle.
+
+## In this chapter
+
+- [**Data Provider side**](provider.md) – what [Data Providers](../../glossary.md#data-provider) do (Publication Layer; Data management out of scope).
+- [**Service Platform side**](platform.md) – what [Service Platforms](../../glossary.md#service-platform) do (Function mapping, Data Layer, Presentation Layer).
+
+## Related
+
+- [DERA](https://dera.netwerkdigitaalerfgoed.nl/index.php/Applicatiearchitectuur) – the network-wide architectural reference; the four-layer model is being added there.

--- a/docs/stack/layers/platform.md
+++ b/docs/stack/layers/platform.md
@@ -1,0 +1,476 @@
+---
+sidebar_position: 2
+toc_max_heading_level: 4
+---
+
+# Service Platform side
+
+:::warning Draft – under review
+Part of the Stack documentation ([overview](../index.md)). Not yet endorsed by NDE.
+:::
+
+Service Platforms consist of a [Data Layer](#data-layer) and [Presentation Layer](#presentation-layer).
+The Data Layer assembles network data into derived products; the Presentation Layer renders them for users.
+
+## Function mapping
+
+[*Van data naar dienst*](https://zenodo.org/records/17541400) defines ten functions (eight in the Data Layer, two in the Presentation Layer). The table below maps each onto what exists today (in [`ldelements/lde`](https://github.com/ldelements/lde) and in [`netwerk-digitaal-erfgoed/*`](https://github.com/netwerk-digitaal-erfgoed)) and what is proposed but not yet built. Empty cells (—) are real gaps. A package can appear under multiple functions if it genuinely contributes to several. Source-side components are not in this table; they appear in the [Publication Layer](provider.md#publication-layer).
+
+The Stack standardises on [`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline) as the [pipeline orchestrator](../pipeline.md); the rows below list pipeline-stage packages that plug into it. Specific Writers or Executors are called out per row where relevant.
+
+| Step | Function                   | Existing LDE (`@lde/*`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Existing NDE                                                                                                            | Proposed / TBD                                                                                                                                                                                                                                                                                                  |
+|------|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1    | Access                     | [`dataset-registry-client`](https://github.com/ldelements/lde/tree/main/packages/dataset-registry-client), [`distribution-downloader`](https://github.com/ldelements/lde/tree/main/packages/distribution-downloader), [`distribution-probe`](https://github.com/ldelements/lde/tree/main/packages/distribution-probe), [`distribution-monitor`](https://github.com/ldelements/lde/tree/main/packages/distribution-monitor), [`sparql-importer`](https://github.com/ldelements/lde/tree/main/packages/sparql-importer), [`sparql-qlever`](https://github.com/ldelements/lde/tree/main/packages/sparql-qlever) | [NDE Datasetregister](../../services/dataset-register)                                                                  | Pipelines read distribution health from the [Register’s health graph](../../services/dataset-register/data-model.md#distribution-health) rather than re-probing; ad-hoc probes can call [`distribution-probe`](https://github.com/ldelements/lde/tree/main/packages/distribution-probe) directly. LDES Executor |
+| 2    | Discovery                  | [`dataset-registry-client`](https://github.com/ldelements/lde/tree/main/packages/dataset-registry-client) (`SearchCriteria` filter), [`pipeline-void`](https://github.com/ldelements/lde/tree/main/packages/pipeline-void)                                                                                                                                                                                                                                                                                                                                                                                 | [NDE Dataset Knowledge Graph](../../services/dataset-knowledge-graph)                                                   | Mature “Knowledge Graph voor Datasets” network service; advisor service surfacing DKG analyses to dienstplatformen                                                                                                                                                                                              |
+| 3    | Normalisation              | —                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | —                                                                                                                       | Wrapper services for AI-tooling at network level (HTR / ATR / ASR / NER)                                                                                                                                                                                                                                        |
+| 4a   | Transformation (technical) | [`distribution-downloader`](https://github.com/ldelements/lde/tree/main/packages/distribution-downloader), [`sparql-importer`](https://github.com/ldelements/lde/tree/main/packages/sparql-importer), [`sparql-qlever`](https://github.com/ldelements/lde/tree/main/packages/sparql-qlever)                                                                                                                                                                                                                                                                                                                | —                                                                                                                       | SHACL-driven transformation generator – the realisation of [`ldelements/lde#325`](https://github.com/ldelements/lde/issues/325)                                                                                                                                                                                 |
+| 4b   | Transformation (semantic)  | —                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [SCHEMA-AP-NDE-first](../patterns.md#schema-ap-nde-first) | domain-profile adapters (Linked Art / CIDOC-CRM, RiC-O, RDA, EDM)                                                                                                                                                                                                             |
+| 5    | Enrich                     | —                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | [NDE Network of Terms](../../services/network-of-terms)                                                                 | `@ndes/pipeline-tn-enrich` (calls NoT); NDE “Knowledge Graph voor Termen” network service (term ↔ term, [report function 5](#function-mapping), substrate C); **Term Backlink Graph** (term ↔ record, substrate B)                                                                                                          |
+| 6    | Build knowledge graph      | [`sparql-qlever`](https://github.com/ldelements/lde/tree/main/packages/sparql-qlever), [`sparql-server`](https://github.com/ldelements/lde/tree/main/packages/sparql-server), [`local-sparql-endpoint`](https://github.com/ldelements/lde/tree/main/packages/local-sparql-endpoint), [`pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline)                                                                                                                      | —                                                                                                                       | `@ndes/pipeline-terms-kg-project`; `netwerk-digitaal-erfgoed/term-kg` (Term Backlink Graph deployment repo); `netwerk-digitaal-erfgoed/stack` (Nx monorepo for `@ndes/*` packages)                                                                                                                                          |
+| 7    | Build search index         | [`pipeline-shacl-validator`](https://github.com/ldelements/lde/tree/main/packages/pipeline-shacl-validator), [`pipeline-shacl-sampler`](https://github.com/ldelements/lde/tree/main/packages/pipeline-shacl-sampler), [`pipeline-void`](https://github.com/ldelements/lde/tree/main/packages/pipeline-void)                                                                                                                                                                                                                                                                                                | —                                                                                                                       | `@lde/pipeline-construct-extract`, `@lde/pipeline-frame-reshape`, `@lde/pipeline-typesense-load`, `@lde/pipeline-typesense-alias-swap`; `@ndes/schema-profile-search-config` (object search), `@ndes/dcat-ap-nl-search-config` (catalog search over dataset descriptions); Search pipeline                                                                                                                   |
+| 8    | Expose Data Layer          | [`fastify-rdf`](https://github.com/ldelements/lde/tree/main/packages/fastify-rdf)                                                                                                                                                                                                                                                                                                                                                                                                                                   | —                                                                                                                       | `@lde/graphql-server` (Mercurius); `@lde/rest-server`, `@lde/ldes-static-writer`                                                                                                                                                                                                                                |
+| 9    | Retrieve metadata          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | —                                                                                                                       | Per-deployment presentation-layer adapters fetching the Data Layer’s GraphQL – directly from the browser ([Projection mode](#two-consumption-modes)’s single round-trip), or via a server-side rendering layer for SEO or multi-backend fan-in                                                                                                                                                                                                                          |
+| 10   | Present metadata           | (out of scope)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | —                                                                                                                       | `@ndes/heritage-ui-components`                                                                                                                                                                                                                                                                                  |
+> 
+How to read this table:
+
+- **A package in the Existing LDE column** is generic, data-model-agnostic, network-agnostic – usable by anyone, not just NDE deployments.
+- **A package in the Existing NDE column** carries NDE-network specifics (calls NDE-operated services, uses NDE conventions, references SCHEMA-AP-NDE).
+- **A proposal prefixed `@lde/*`** belongs in `ldelements/lde` because it is reusable beyond NDE; `@ndes/*` belongs in `netwerk-digitaal-erfgoed/stack` because it depends on NDE-network specifics. Pieces can move between orgs as their reusability becomes clear.
+- **Gaps (—) are not all equal.** [Function 3](#function-mapping) is empty because normalisation is positioned in the report as a Data Provider concern, not a Service Platform engine concern. [Function 10](#function-mapping) is empty because presentation components live in the application layer the Stack supports rather than constituting it.
+- **[Functions 8](#function-mapping) and [9](#function-mapping) are two sides of one contract.** Function 8 (Expose Data Layer) is the provider end: the Data Layer serves its GraphQL/REST API. Function 9 (Retrieve metadata) is the consumer end: the Presentation Layer reads from that same API – directly from the browser, or through a server-side rendering layer where one is needed. They sit in separate functions only because the Data Layer ↔ Presentation Layer boundary – usually an ownership boundary too – runs between provider and consumer; the API schema is their single coupling point.
+
+## Data Layer
+
+Service Platform internals: discovering sources, ingesting their data, harmonising, enriching, building knowledge graphs and search indexes, exposing the result via APIs ([functions 1–8](#function-mapping)). This is where the Stack does most of its work, and where most of the current content lives.
+
+The [Substrates](../index.md#substrates) section in the overview names three crawl substrates (A: dataset descriptions, B: dataset contents, C: terminology sources); the components and patterns below refer back to them by letter.
+
+### Components
+
+#### Search Pipeline
+
+Implements
+: [Report function 7](#function-mapping) (Build search index), with slices of 1, 2, 5
+
+Instantiates
+: [Configurable Pipeline](../patterns.md#configurable-pipeline)
+
+Uses
+: [Discovery via DCAT-AP Registry](../patterns.md#discovery-via-dcat-ap-registry), [Augmented Dataset Selection](../patterns.md#augmented-dataset-selection), [Change-driven Rebuild](../patterns.md#change-driven-rebuild), [Last-known-good Per-source Caching](../patterns.md#last-known-good-per-source-caching), [Blue/green Rebuild](../patterns.md#bluegreen-rebuild)
+
+Provides
+: [Search APIs](#search-apis) (downstream)
+
+The **Search Pipeline takes a filtered set of records from selected datasets and generates typed GraphQL and REST APIs that consumers can query** *(proposed, under design)*. The search index that backs the APIs is generated too, but it is an internal artifact – consumers see only the APIs. It is AP-aware: SHACL + `search:` annotations + JSON-LD Framing drive both the APIs (GraphQL SDL + resolvers, OpenAPI + routes) and the projection from RDF into an engine-agnostic framed document; an engine adapter materialises that into Typesense (Elasticsearch/OpenSearch may follow). The first deployment is the [Dataset Register](../../services/dataset-register/) browser-search, from two sources: provided descriptions ([DCAT-AP-NL](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/)) and DKG summaries expressed in [VoID](https://www.w3.org/TR/void/) (Vocabulary of Interlinked Datasets) and [DQV](https://www.w3.org/TR/vocab-dqv/) (Data Quality Vocabulary).
+
+The Stack’s Data Layer pipelines ([Search](#search-pipeline) and [Knowledge Graph](#knowledge-graph-pipeline)) are **configured by linked-data standards** – SHACL shapes for projection, SPARQL CONSTRUCT for extraction, JSON-LD Framing for output shaping – not by bespoke Python scripts. Custom code lives only at port/adapter boundaries (a writer, a filter compiler). Each is a configuration of [`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline) over the [shared pipeline stages](../pipeline.md#stages) (Discover → Select → Read → Project → Validate → Materialise → Serve): they share the upstream (Discover, Select, Read) and diverge from **Project** onward, where the target shape determines validation, sink, and API.
+
+The rest of this section describes the Search specialisation in detail; [Knowledge Graph Pipeline](#knowledge-graph-pipeline) below specifies only where it differs.
+
+##### Architecture: two-stage split
+
+SHACL together with a `search:` annotation vocabulary is the single source of truth. This SHACL describes *the index*: every NodeShape, every PropertyShape, every cardinality, every datatype constraint is what the framed document will contain. The shape graph is normally the upstream AP’s published SHACL; what diverges the index is the `search:` annotation overlay, not the shapes. `search:indexed false` drops a property from the projection, and nested-shape strategies (`labelOnly`, `idOnly`, `inline`) reshape what a referenced node looks like in the index – both without touching the `sh:` constraints. Only an explicit `sh:` override (e.g. tightening `sh:maxCount`) actually deltas the shape graph itself, and that is the exception. The projection SHACL is what the CONSTRUCT extracts, what the validator validates, and what the GraphQL SDL and REST OpenAPI types are derived from.
+
+The pipeline splits in two so the search engine is a swappable adapter:
+
+```mermaid
+flowchart LR
+    A["SHACL shapes<br/>+ search: vocab"]
+
+    subgraph Extraction ["Extraction"]
+        D["SPARQL CONSTRUCT<br/>(per shape)"]
+    end
+    A --> D
+
+    subgraph APIs ["APIs"]
+        B["GraphQL API<br/>(SDL + resolvers)"]
+        C["REST API<br/>(OpenAPI + routes)"]
+    end
+    A --> B
+    A --> C
+
+    subgraph Index ["Search index"]
+        E["Search document<br/>(engine-agnostic)"]
+        subgraph Adapters ["Engine adapters"]
+            F["Typesense"]
+            G["Elasticsearch"]
+            I["OpenSearch"]
+        end
+        E --> F
+        E --> G
+        E --> I
+    end
+    A --> E
+```
+
+- **Engine-agnostic projection** consumes SHACL + `search:` annotations and emits four artifacts with zero search-engine specifics: SPARQL CONSTRUCT (one per NodeShape with `sh:targetClass`), a GraphQL API (SDL **and** resolvers), a REST API (OpenAPI spec **and** route handlers), and a generic, engine-agnostic **framed document** (one framed JSON-LD document per resource). GraphQL and REST surfaces are co-specified and co-implemented, not maintained separately.
+- **Engine adapter** consumes that format and the framed documents and produces engine-specific collection schemas, documents, and the filter compiler that translates typed GraphQL filter inputs into the engine’s query language. Typesense is the v1 adapter; Elasticsearch and OpenSearch follow the same shape.
+
+The framed document is the seam where the [Ports & Adapters](../patterns.md#adapters) pattern lands for search: it plays the role of an *intermediate representation* (in the compiler sense) – the one neutral form where the projection and the engine adapters meet, so a single projection serves N engines instead of forking per engine. A Service Platform typically deploys with one search engine; a different Service Platform on the network may deploy with a different one. Adapters make that a per-deployment choice, not a per-pipeline fork – the upstream projection stays the same regardless of which engine a deployment picks.
+
+##### Example: a SCHEMA-AP-NDE document, framed for indexing
+
+The framed document is **RDF** – specifically *framed JSON-LD*, one of RDF’s standard serialisations. The clever property: it reads cleanly as plain JSON for tools that don’t know RDF (search engines, vector databases, UI components), while remaining valid RDF for tools that do. The framing applies a JSON-LD Frame generated from SHACL + `search:` annotations to flatten the underlying graph into the desired tree shape.
+
+It is **almost entirely SCHEMA-AP-NDE**. Same vocabulary (`schema:name`, `schema:creator`, `schema:dateCreated`, `schema:material`, `schema:about`, …), same types (`CreativeWork`, `Person`, `DefinedTerm`), same URI conventions. What changes is the **JSON-LD framing**: a specific tree shape derived from the SHACL shapes + `search:` annotations, plus a context that encodes search-friendly conventions (per-language envelope, embedded term labels, etc.).
+
+A typical framed document, combining several SCHEMA-AP-NDE properties (`CreativeWork-name`, `CreativeWork-creator`, `CreativeWork-dateCreated`, `CreativeWork-material`, `CreativeWork-about`) for an example record:
+
+```json title="Framed document example: Vincent van Gogh, The Starry Night (framed JSON-LD 1.1)"
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+    "search": "https://ldelements.org/ns/search#",
+    "name":     { "@id": "schema:name",     "@container": "@language" },
+    "creator":  { "@id": "schema:creator",  "@type": "@id" },
+    "material": { "@id": "schema:material", "@type": "@id" },
+    "about":    { "@id": "schema:about",    "@type": "@id" }
+  },
+  "@id": "https://example.com/dataset1/the-starry-night",
+  "@type": "CreativeWork",
+  "name": {
+    "nl": "De Sterrennacht",
+    "en": "The Starry Night"
+  },
+  "creator": [
+    {
+      "@type": "Person",
+      "name": { "nl": "Vincent van Gogh" },
+      "sameAs": "https://data.rkd.nl/artists/32439"
+    }
+  ],
+  "dateCreated": "1889-06",
+  "material": [
+    {
+      "@id": "http://vocab.getty.edu/aat/300015050",
+      "name": { "nl": "olieverf" }
+    }
+  ],
+  "about": [
+    { "name": { "en": "night sky" } }
+  ],
+  "image": "https://example.com/starry-night.jpg"
+}
+```
+
+Semantics worth noting:
+
+- **Multilingual envelope** (`@container: @language`): `name` collapses to `{ "nl": …, "en": … }`. Engines that support nested objects (Typesense `enable_nested_fields`, Elasticsearch `nested`) preserve per-language stemming and IDF; a flat `string[]` would lose them. See the [Multilingual envelope](#multilingual-envelope) section for the rationale.
+- **`search:labelOnly` default for nested objects**: `creator`, `material`, and `about` carry only `@id`, `@type`, and `name` – not the full graph of the referenced entity. The inline labels drive detail-page rendering and BM25 within this dataset’s curatorial vocabulary; cross-dataset canonical labels come from the separate `terms` collection (see [Term labels](#term-labels-two-sources-two-purposes)).
+- **Term URIs preserved as `@id` or `sameAs`** (Getty AAT for *olieverf*; RKD for Van Gogh): URIs remain queryable as URIs while labels feed text search. The context entry `"creator": { "@id": "schema:creator", "@type": "@id" }` declares the property’s range as IRI – it does not automatically promote `sameAs` to `@id`; that is a SHACL+annotations modelling choice (canonicalise to one identifier vs. preserve both).
+- **Engine-blind**: the framed document contains no SHACL, no `search:` annotations, no Typesense/Elasticsearch specifics. Adapters consume only this format + a corresponding generated schema.
+- **Standards-grounded**: every triple in the document is still valid SCHEMA-AP-NDE RDF. Round-tripping back to the source vocabulary is a JSON-LD framing-inverse step.
+
+So a framed document is a SCHEMA-AP-NDE record reshaped for indexing – not a new vocabulary, just a frame.
+
+##### Other framed-document targets
+
+The framed document is engine-agnostic, but more importantly it is *sink-agnostic*. Anything that can consume a stream of typed, framed JSON-LD documents per resource can plug in as another engine adapter. Realistic targets, current and proposed:
+
+- **Search engines** (current): Typesense / Elasticsearch / OpenSearch. The keyword-search path.
+- **Embedding indexes** *(proposed)*: Weaviate, Qdrant, pgvector, Typesense vectors. An embedding adapter selects which framed-document fields to embed (typically `name[*]`, `about[*].name`, descriptive text), runs them through a model (sentence-transformers, OpenAI embeddings, etc.), and writes URI + vector pairs to the vector store. Pairs with the search engine adapter to enable **hybrid search** (BM25 + semantic).
+- **LDES republishing** *(proposed)*: each framed document becomes an LDES member; downstream consumers subscribe instead of re-deriving. See the [Change Stream Producer](#change-stream-producer) component.
+- **Heritage UI / presentation rendering** *(future)*: Heritage UI Components consume framed documents directly to render pre-built pages, without going through the search engine. Maps to [report function 10](#function-mapping) (Presentatie).
+- **Dashboards, recommendations, document stores**: any consumer that wants the typed per-resource document stream.
+
+**EDM export is not one of these.** Europeana aggregation is produced by a *separate* pipeline ([loda-pipeline, PR #14](https://github.com/netwerk-digitaal-erfgoed/loda-pipeline/pull/14)) that maps each dataset’s **SCHEMA-AP-NDE** into EDM via SPARQL CONSTRUCT in QLever. It is a downstream consumer of [SCHEMA-AP-NDE-first](../patterns.md#schema-ap-nde-first) – reading the full pivot representation, not the search-pruned framed document – and a sibling of the Search and Knowledge Graph pipelines; see [Example: EDM export](../pipeline.md#example-edm-export-loda-pipeline).
+
+:::note Report alignment
+
+The report *Van data naar dienst* names AI tooling for **upstream content extraction** ([stap 3 Ontwikkeling](#function-mapping) – HTR, ATR, ASR, NER) and *graph-semantic* enrichment of search ([stap 7](#function-mapping) – *“geavanceerde zoekmachines maken slim gebruik van de semantiek die in de linked data is vastgelegd”*). It does **not** explicitly call for vector-embedding semantic search, hybrid retrieval (BM25 + dense), or LLM-based discovery. The embedding-adapter direction above is therefore a Stack-direction extension beyond what the report prescribes
+
+:::
+
+##### Pipeline phases
+
+Stages 1–3 of the [pipeline spine](../pipeline.md#stages) (Discover, Select, Read) run first; the search pipeline then expands stages 4–7 (Project, Validate, Materialise, Serve) into seven phases with explicit input/output contracts:
+
+| Phase | Input | Output | Driven by |
+| --- | --- | --- | --- |
+| 1. Enumerate | Source RDF | Stream of resource URIs per `sh:targetClass` | SHACL `sh:targetClass`; optional `sh:filterShape` / named-graph scope |
+| 2. Extract | A resource URI | Subgraph sufficient to populate the document | Generated parameterised CONSTRUCT per target class |
+| 3. Reshape | Subgraph + JSON-LD Frame | Framed JSON tree matching the engine-agnostic schema | Frame generated from SHACL + `search:` annotations |
+| 4. Validate | Framed document | Validated document + violation report | Projection SHACL (the [SHACL-honest](#non-conformant-source-data) policy) |
+| 5. Adapt | engine-agnostic schema + framed document | Engine-specific schema + document JSON | Engine adapter |
+| 6. Index | Engine schema + documents | Live alias-swapped collection | Bulk import + alias swap |
+| 7. Resolve *(query-time)* | GraphQL query | Typed result | Generated SDL + adapter’s filter compiler |
+
+Phases 1–4 are the **engine-agnostic projection**; phases 5–6 the **engine adapter**; phase 7 is split (SDL generation in the projection, filter compilation in the adapter).
+
+Phase 2 uses a generated parameterised CONSTRUCT per target class – not CBD or `DESCRIBE`. CBD can’t express predicate filtering or configurable depth, and `DESCRIBE`’s exact shape is implementation-defined across triplestores. Phase 3 uses W3C JSON-LD Framing: `@container: @language` for multilingual properties, `@embed: @always` with restricted property lists for `labelOnly`, `@embed: @never` for `idOnly`.
+
+##### From SHACL to engine and API
+
+The base SHACL-to-engine-and-API mapping is mechanical:
+
+| SHACL | Search engine (Typesense example) | GraphQL |
+| --- | --- | --- |
+| `sh:targetClass` | What to iterate in CONSTRUCT | Object type |
+| `sh:path` | Property path in WHERE | Field |
+| `sh:datatype xsd:integer` etc. | `type: int64` / `float` / `string` | `Int` / `Float` / `String` |
+| `sh:maxCount 1` | Scalar; else `string[]` / `int64[]` | Nullable scalar vs list |
+| `sh:minCount ≥ 1` | Required | Non-null |
+| `sh:languageIn ("nl" "en")` | `title_nl`, `title_en` (nested-object form) | `[LanguageString!]!` |
+| `sh:in (…)` | Facet candidate | Enum |
+| `sh:node` / `sh:class` | Nested object OR engine `reference` join | Nested type with `@reference` |
+
+What SHACL alone doesn’t express – facetability, sortability, full-text inclusion, embedding, per-language field explosion, nested-shape strategy, collection naming – lives in a separate annotation graph at `https://ldelements.org/ns/search#` (prefix `search:`). The vocabulary is engine-agnostic by design (`search:facetable`, not `typesense:facet`); engine-specific tuning lives in separate vocabularies (`tsx:` for Typesense, `esx:` for Elasticsearch) loaded as additional graphs.
+
+The expectation is that annotating SCHEMA-AP-NDE is the rare exception, not the rule. SCHEMA-AP-NDE ships with sane `search:` defaults via the proposed `@ndes/schema-profile-search-config`; a deployment’s own annotations file is a thin delta layer that only declares overrides.
+
+##### Two consumption modes
+
+The same SHACL-driven pipeline powers two architecturally different consumer setups; the choice depends on whether the consuming frontend is RDF-native.
+
+- **Projection mode.** Engine documents carry the full denormalised search-relevant payload; the GraphQL API resolves typed fields from the search engine directly. Single round-trip per page; works for non-RDF frontends. Default for new consumer-facing applications.
+- **URI-filter mode.** Engine indexes only the fields needed for search / facet / sort / pagination and returns URIs only (plus facet counts, total, page cursor). The RDF-native frontend hits SPARQL with `VALUES ?s { … }` for the actual graph. Preserves graph semantics end-to-end; suitable for retrofitting search onto a site that already speaks RDF.
+
+URI-filter mode is Projection mode with `search:nestedStrategy search:idOnly` everywhere and a thinner GraphQL surface. Same generator, same configuration shape.
+
+##### Multilingual envelope
+
+Multilingual properties (`rdf:langString` / `sh:languageIn`) project as a nested object: `name: { nl: "...", en: "..." }`, with `enable_nested_fields: true` on every collection. In GraphQL this surfaces as `[LanguageString!]!` (ordered by `Accept-Language` preference), where `LanguageString { language, value }` matches the [Network of Terms](../../services/network-of-terms/)’ existing GraphQL API.
+
+This preserves per-language stemming, IDF and query-time boosting (the engine binds `locale` to a field path, not to an array element). A single multi-valued `string[]` field would lose those.
+
+##### Term labels: two sources, two purposes
+
+Term labels enter the index from two distinct sources, serving two distinct UI concerns:
+
+- **Inline labels in the parent document** (the default `search:labelOnly` nested strategy) come from the *source dataset*. They drive detail-page rendering and BM25 within that dataset’s curatorial vocabulary.
+- **A separate `terms` collection** populated from the [Network of Terms](../../services/network-of-terms/)’ GraphQL Lookup endpoint. It drives cross-dataset faceted search with canonical labels across all configured sources, regardless of how each underlying record labelled the term (or whether it labelled it at all).
+
+A dedicated pipeline phase populates the `terms` collection; it does not rewrite labels in parent documents. Source-faithful and canonical labels coexist.
+
+##### Document is the materialised view
+
+In Projection mode the engine document is the materialised view of the resource per the SHACL projection – not just a search-result row. Detail-page rendering reads from the same document: search and detail pages are both queries against the same materialised view, snapshot-consistent through the alias swap. There is no separate SPARQL store on the detail-page read path.
+
+Watch-items, not blockers: Typesense’s 1 MB document limit can be hit by long-form text × multiple languages × inlined labels (mitigation: `index: false` for display-only fields, truncation, external storage for overflow). The ∼1000-field soft limit per collection is comfortably above typical AP shapes.
+
+##### Source-RDF topology
+
+A search-subsystem instance ingests from one or more NDE-conformant source datasets, processed independently into a shared rebuild collection. No aggregation step, no staging triplestore. Identity across datasets is URI equality; per-resource projection needs only the resource’s own dataset plus term labels from the Network of Terms.
+
+Per-dataset processing is naturally change-data-capture (CDC)-friendly (each source has its own freshness cadence) and gives failure isolation (one source’s outage doesn’t halt the others). Cross-dataset graph analytics (“merge two source descriptions of the same Place into one richer record”) are out of scope; that is a separate aggregation layer’s concern.
+
+##### Multiple data models across sources
+
+Sources publishing different APs don’t force a unioned, permissive SHACL. The projection contract is one AP at a time:
+
+- **One AP per projection.** A pipeline run reads one SHACL shape graph plus one `search:` annotation graph and produces one collection. A dataset that publishes both SCHEMA-AP-NDE and Linked Art is read against whichever AP the projection is configured for; the other representation is ignored at index time. See [Parallel data models](../patterns.md#parallel-data-models) for the publication-side commitment that makes this safe.
+- **Multi-AP search = parallel projections, not a wider SHACL.** A deployment that wants Linked-Art-driven search alongside SCHEMA-AP-NDE-driven search runs a second projection with a different annotation package (e.g. `@ndes/linked-art-search-config`) against the same sources, producing a separate collection with its own GraphQL root type. Same pipeline, same generator – different shapes, different annotations.
+- **Sources publishing only a non-NDE AP** (no SCHEMA-AP-NDE shape at all) sit outside the SCHEMA-AP-NDE projection. They can either be picked up by a parallel projection for their AP, harmonised upstream into SCHEMA-AP-NDE (function 4 / [`ldelements/lde#325`](https://github.com/ldelements/lde/issues/325)), or skipped.
+- **Extensions** ride on AP-defined extension points (`additionalType`, `subjectOf`, etc.) or on a per-deployment annotation delta layered on top of the base AP’s `search:` defaults. They never relax the base shape.
+
+The architectural consequence: “what if my crawled datasets speak different APs?” turns into “how many collections does this deployment produce?” – a configuration question, not a shape-design one. Each collection has a strict, single-AP SHACL.
+
+##### Update modes
+
+| Mode | Trigger | State per document | Atomicity |
+| --- | --- | --- | --- |
+| 1. Full alias-swap rebuild (default) | All sources at once | None | Atomic |
+| 2. Per-source upsert + sweep | One source changes | `source`, `last_seen` | Source-scoped |
+| 3. Per-resource incremental | Per-resource CDC | Snapshot diff or LDES | Resource-scoped |
+
+Default is Mode 1: atomic, no state, simple to reason about. Mode 2 is designed in (every document carries `source` and `last_seen` from day one) but not activated until source cadences diverge enough to make Mode 1 wasteful. Mode 3 stays out of scope until upstream LDES feeds appear.
+
+This is the engine-native variant of the [Blue/green Rebuild](../patterns.md#bluegreen-rebuild) pattern, specialised to the search engine’s collection-alias API.
+
+##### Non-conformant source data
+
+Real heritage datasets carry violations against the projection SHACL. The indexing policy is SHACL-honest – because the projection SHACL is exactly what the index should contain (see [Architecture](#architecture-two-stage-split) above), the validator’s rules and the indexer’s decisions are the same rules:
+
+| Violation on… | Pipeline policy |
+| --- | --- |
+| A property with `sh:minCount 0` in the projection SHACL (optional in the index) | Drop the offending value from the indexed document. Log. Index the resource without that field. |
+| Anything else – a missing `sh:minCount ≥ 1` property, a `sh:targetClass` constraint, a `sh:datatype` / `sh:pattern` / `sh:in` violation on a required property | Reject the resource. Log. |
+
+The rule reduces to: if the projection SHACL says the field is required, the indexer treats it as required; if optional, a bad value gets dropped but the resource still makes it into the index. A deployment that wants stricter or laxer behaviour for a specific property tightens or relaxes the cardinality in its annotation delta – not by adding pipeline configuration, but by editing the shape that *is* the index’s contract.
+
+Validation uses `@lde/pipeline-shacl-validator` (the same engine the [Dataset Knowledge Graph](../../services/dataset-knowledge-graph/) uses for its conformance step); scope is per-resource, not sampled. A CI threshold fails the rebuild if the rejection rate jumps by more than a configurable percentage versus the previous run – catches a sudden source regression before it nukes the index.
+
+#### Search APIs
+
+Implements
+: [Function 8](#function-mapping) (Expose) for search: the presentation-layer-facing API. The KG slice of Expose lives in [Knowledge Graph APIs](#knowledge-graph-apis) below
+
+Uses
+: [Stable API Contract](../patterns.md#stable-api-contract)
+
+Provides
+: Typed GraphQL and REST surface for Presentation Layers
+
+Both the GraphQL API (schema and Mercurius resolvers) and the REST API (OpenAPI spec and Fastify route handlers) are generated by the [Search Pipeline](#search-pipeline)’s engine-agnostic projection from the same SHACL + `search:` source. Hand-writing either spec or its implementation is the bug, not the feature.
+
+The Search APIs face the Presentation Layer; they expose the search index produced by the [Search Pipeline](#search-pipeline). GraphQL and REST forms are derived from the same SHACL + `search:` source of truth that drives the pipeline – SDL generation is part of the projection step, not a separate hand-written contract.
+
+##### GraphQL API: shaped for web developers, not RDF specialists
+
+The Data Layer’s GraphQL API is the contract to the Presentation Layer. Its primary audience is web developers building consumer-facing applications, most of whom won’t know SHACL, SPARQL, URIs as a first-class concept, or language-tagged literals as a distinct datatype. The API surface is shaped accordingly:
+
+- Standard GraphQL idioms throughout – Prisma-style typed filter inputs (`where: { field: { eq, in, gt, … } }`), Relay Connection pagination (`first` / `after` / opaque cursor), facet arrays with counts.
+- URIs surface as `String`, not as a custom `IRI` scalar. Numbers, strings and booleans are GraphQL primitives.
+- Language selection via HTTP `Accept-Language`, not GraphQL arguments.
+- Localised strings as `[LanguageString!]!` lists ordered by Accept-Language preference.
+- One round trip per page; detail pages read from the same store as search results.
+- Plain SDL, standard `POST /graphql`, standard GraphQL error shape – idiomatic tooling (codegen, IDE autocomplete, persisted queries, fragment composition) works out of the box.
+
+##### REST API
+
+The same search index is also exposed as a plain HTTP/JSON REST API, for consumers that don’t want a GraphQL client, such as simple server-to-server integrations, scripts, and CDN-cached reads. Its OpenAPI spec and Fastify route handlers come from the same SHACL + `search:` source as the GraphQL surface, so the two never drift.
+
+- A **fixed query-parameter grammar for filters and facets**, generated from the same SHACL + `search:` annotations as the GraphQL filter inputs. REST has no native convention for this, so the Stack defines one – every deployment exposes the same filter and facet syntax rather than inventing its own. Pagination uses the same cursor model as GraphQL Connections.
+- An OpenAPI 3 description drives client codegen and IDE tooling; `GET` requests carry HTTP caching (`ETag` / `Cache-Control`) – an edge the single `POST /graphql` endpoint does not get for free.
+- URIs surface as `string`; localised strings use the same `LanguageString` shape, with language selection via `Accept-Language` rather than a query parameter – identical to GraphQL.
+- Served by the same Fastify runtime as the GraphQL API (Mercurius), so both share one process, one auth layer, and one deployment.
+
+This is the data-layer side of the [Stable API Contract](../patterns.md#stable-api-contract) pattern: the consumer never sees the underlying SHACL-driven RDF projection. That insulation is what lets the Data Layer re-shape its SHACL, re-model the RDF, or swap the search engine without breaking consumers; lets web developers build without RDF, SPARQL or SHACL expertise; and lets a Presentation Layer consume any Data Layer on the network – or several at once – through one typed contract instead of per-platform mapping.
+
+#### Knowledge Graph Pipeline
+
+Implements
+: [Report function 6](#function-mapping) (Build knowledge graph)
+
+Instantiates
+: [Configurable Pipeline](../patterns.md#configurable-pipeline)
+
+Uses
+: [Discovery via DCAT-AP Registry](../patterns.md#discovery-via-dcat-ap-registry), [Augmented Dataset Selection](../patterns.md#augmented-dataset-selection), [Change-driven Rebuild](../patterns.md#change-driven-rebuild), [Last-known-good Per-source Caching](../patterns.md#last-known-good-per-source-caching), [Blue/green Rebuild](../patterns.md#bluegreen-rebuild)
+
+Provides
+: [Knowledge Graph APIs](#knowledge-graph-apis) (downstream)
+
+The KG pipeline shares the [Search Pipeline](#search-pipeline)’s upstream (Discovery → Selection → Source reading → Change detection → Last-known-good caching) and its standards-backed framing. It differs at projection, sink, and API:
+
+| | Search pipeline | KG pipeline |
+| --- | --- | --- |
+| Projection | SHACL + `search:` annotations + JSON-LD Framing → framed documents | SHACL + SPARQL CONSTRUCT → RDF (n-quads) |
+| Sink | Search engine (Typesense alias swap; Elasticsearch / OpenSearch follow) | Triplestore (QLever, directory-level blue/green) |
+| Deploy options | [Blue/green](../patterns.md#bluegreen-rebuild) or [In-place](../patterns.md#in-place-rebuild) | [Blue/green](../patterns.md#bluegreen-rebuild) only – QLever is read-only after load |
+| API surface | [Search APIs](#search-apis) (GraphQL + REST) derived from the same SHACL | SPARQL endpoint over the loaded triples (per [Knowledge Graph APIs](#knowledge-graph-apis)) |
+
+**KG-specific specialisation details:**
+
+- **Backend: QLever.** Read-only-after-load model fits the per-rebuild lifecycle of Stack KGs; bulk-loads `.nq` dumps fast. Alternatives (Oxigraph, GraphDB, Jena Fuseki) only when a feature-specific reason applies.
+- **Per-source writer: [`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline)’s `FileWriter`** with `format: 'n-quads'`, one file per `Dataset` (filename derived from `dataset.iri`).
+- **Configuration shape:** what differs between KG instances is the *projection logic* over the chosen substrate – AP-aware vs data-model-agnostic vs custom – and which annotations/SHACL drive it. The engine, writer, rebuild mechanics, and discovery are reusable.
+
+**The Stack provides building blocks for any Service Platform to build any KG it needs – not a fixed catalog of KGs.** A regional aggregator wanting a thematic KG over its members’ collections uses the same building blocks; a research project building a domain-specific KG over a curated subset does too. The Stack is the *capability layer*; instances – [Knowledge Graph APIs](#knowledge-graph-apis) – are deployments.
+
+#### Knowledge Graph APIs
+
+Implements
+: [Report function 8](#function-mapping) (Expose) for knowledge graphs: the presentation-layer-facing API. Parallel to [Search APIs](#search-apis) on the search side
+
+Uses
+: [Stable API Contract](../patterns.md#stable-api-contract)
+
+Provides
+: SPARQL endpoint and content-negotiated RDF (Turtle, N-Quads, JSON-LD)
+
+APIs over the knowledge graphs built by the [Knowledge Graph Pipeline](#knowledge-graph-pipeline). Each knowledge graph exposes a **SPARQL endpoint** over its loaded triples (QLever); content negotiation returns RDF in standard serialisations via [`@lde/fastify-rdf`](https://github.com/ldelements/lde/tree/main/packages/fastify-rdf). Change-feed access is the same cross-cutting concern as on the search side, not a separate KG API: a KG can be republished as an LDES feed through the [Change Stream Producer](#change-stream-producer) (planned, via `@lde/ldes-static-writer`).
+
+**Network-operated instances** (run by NDE, addressable network-wide):
+
+- **[Dataset Knowledge Graph (DKG)](../../services/dataset-knowledge-graph/)**
+- **Term Backlink Graph** *(proposed)*: maintains backlinks from term URIs to records (and datasets) citing them. Inverse of the Network of Terms (URI → label vs URI → records). SPARQL endpoint in v1; LDES feed when `@lde/ldes-static-writer` lands. **data-model-agnostic by design:** walks any RDF dataset looking for references to URIs from recognised terminology sources, regardless of whether the dataset conforms to SCHEMA-AP-NDE, a domain-specific data model (Linked Art, CIDOC-CRM, RiC-O, RDA, etc.) or no AP at all. The vocab list driving the walk comes from the Network of Terms, not from any AP shape. Producer pipeline: `@ndes/pipeline-terms-kg-project`. Shares substrate B with the search pipeline but with orthogonal projection logic – the search pipeline is AP-aware; the Term Backlink Graph is data-model-agnostic. Same crawl feeds both. Corresponds to the cross-collection term-object KG sketched as a “bijzondere toepassing” in [function 6](#function-mapping).
+- **Knowledge Graph voor Termen** *(proposed, term ↔ term, substrate C)* – planned network service per [report function 5](#function-mapping). Aggregates relations between equivalent / related terms across terminology sources.
+
+**Self-operated instances** (run by a Service Platform, a regional aggregator, a research project, etc.):
+
+A deployment builds its own KG by configuring its substrate(s) and projection logic against the [Knowledge Graph Pipeline](#knowledge-graph-pipeline) building blocks. No new Stack components needed – the same QLever + blue/green rebuild + FileWriter + discovery + caching Stack runs any KG. Per-deployment configuration lives in the deployment’s own repo, separate from `netwerk-digitaal-erfgoed/stack`.
+
+#### Change Stream Producer
+
+Instantiates
+: [Configurable Pipeline](../patterns.md#configurable-pipeline) (with LDES as the sink)
+
+Uses
+: [Discovery via DCAT-AP Registry](../patterns.md#discovery-via-dcat-ap-registry), [Augmented Dataset Selection](../patterns.md#augmented-dataset-selection), [Change-driven Rebuild](../patterns.md#change-driven-rebuild) (Detect mode applies these mechanisms inside the Producer), [Last-known-good Per-source Caching](../patterns.md#last-known-good-per-source-caching)
+
+Provides
+: LDES feed for downstream consumers
+
+Tracks
+: [`ldelements/lde#254`](https://github.com/ldelements/lde/issues/254)
+
+The **Change Stream Producer** *(proposed)* turns a Service Platform’s change detection into a uniform **LDES** output that downstream pipelines and consumers can subscribe to. It is **opt-in**: pipelines work with or without it.
+
+Typical operation is **Detect-only**: the Producer crawls its configured sources (dumps or SPARQL endpoints), computes deltas using the mechanisms in [Change-driven Rebuild](../patterns.md#change-driven-rebuild), and emits LDES members from the inferred change events. In effect the Producer is the Service Platform’s own Change-driven Rebuild output, with an LDES Writer at the end – the same detection logic the platform already needs, exposed for downstream consumers.
+
+An optional **Push ([LDP](https://www.w3.org/TR/ldp/), Linked Data Platform)** input – sources `POST` / `PUT` / `DELETE` RDF resources directly into the Producer – if sources support it: a source that prefers push to publication, or a Service Platform writing its own derived data into the Producer for republication. Most Service Platform Producers don’t need this and run Detect-only.
+
+Whichever input mode is used, the output is the same LDES feed. Downstream consumers ([Search Pipeline](#search-pipeline), [Knowledge Graph Pipeline](#knowledge-graph-pipeline), other Service Platforms) pull it via the existing *LDES from upstream* mechanism in [Change-driven Rebuild](../patterns.md#change-driven-rebuild).
+
+**Why this matters:**
+
+- **Centralises snapshot-CDC complexity** in one place for sources that don’t publish LDES directly. Pipelines that subscribe to a Producer avoid implementing per-source change detection themselves.
+- **Uniform input contract** for any pipeline that opts in: LDES, regardless of how the source publishes. Sources that already publish LDES bypass the Producer entirely.
+- **Orthogonal to pipelines.** No coupling: pipelines that don’t opt in keep their own per-source change detection. Adoption is per-deployment and per-source, not all-or-nothing.
+
+**Tradeoffs:**
+
+- An additional moving part for deployments that adopt it.
+- LDES becomes load-bearing as the Producer’s output contract; consumers that opt in commit to it.
+- Dump-only sources still require snapshot-diffing inside the Producer to synthesise LDES – more costly, and more approximate for deletions, than a source that publishes native LDES.
+
+**Scoping and federation.** A Producer is operated *per Service Platform* and scoped to that platform’s own data; this bounds retention and storage to a manageable size. There is no single all-network Producer – a network-wide event history doesn’t scale. Downstream consumers wanting a cross-source view subscribe to the relevant Producers in parallel; the union of those LDES feeds is the network-level change stream. NDE may operate Producers for specific bounded sources (e.g., for the [Dataset Register](../../services/dataset-register/) or [Network of Terms](../../services/network-of-terms/) change feeds) where the scope is naturally small, but those are source-scoped utilities, not omniscient services.
+
+#### Network Services
+
+Foundational services that the Stack consumes – patterns like [Discovery via DCAT-AP Registry](../patterns.md#discovery-via-dcat-ap-registry), [Enrichments-as-Datasets](../patterns.md#enrichments-as-datasets), and [SCHEMA-AP-NDE-first](../patterns.md#schema-ap-nde-first) are load-bearing on these. Each is **a category of service**, not a hard-coded singleton: the canonical NDE-operated instance is the public one most deployments use, but the Stack architecture supports **self-operated instances** where a deployment has scope-specific needs (private datasets, sector-specific vocabularies, data too specific or too sensitive for network-wide registration).
+
+This mirrors the framing the Stack uses for KGs (capability + canonical instances + self-operated instances). A consumer wanting an autonomous Stack runs its own registry / terminology aggregator / KG; one targeting the public network consumes the NDE-operated instances.
+
+**Dataset registry** (DCAT-AP catalog of `dcat:Dataset` descriptions)
+
+- **Canonical NDE-operated instance:** [NDE Dataset Register](../../services/dataset-register/) – the network-wide public catalog.
+- **Self-operated scenarios:** private datasets that cannot be exposed publicly (rights, embargo, sensitive material); scoped catalogs too specific for the country-wide register (a research project’s curated subset, a regional aggregator’s member-only catalog, a sector-specific feed); experimental / staging catalogs during development.
+- **Stack patterns depending on it:** [Discovery via DCAT-AP Registry](../patterns.md#discovery-via-dcat-ap-registry) (the [`@lde/dataset-registry-client`](https://github.com/ldelements/lde/tree/main/packages/dataset-registry-client) package works against any DCAT-AP 3.0 catalog, not specifically the NDE one); [last-known-good caching](../patterns.md#last-known-good-per-source-caching) (registry membership is the cache-retention signal); [Enrichments-as-Datasets](../patterns.md#enrichments-as-datasets) (the registry is the publication target).
+
+**Terminology aggregator** (URI → label, term ↔ term)
+
+- **Canonical NDE-operated instance:** [NDE Network of Terms](../../services/network-of-terms/) – aggregates recognised terminology sources (AAT, GTAA, RKDartists, …), resolves term URIs to multilingual labels.
+- **Self-operated scenarios:** sector-specific vocabularies not yet in the network-wide Network of Terms; private terminology sources with restricted access; experimental vocabularies during development.
+- **Stack patterns depending on it:** the Term Backlink Graph’s vocab list (which URIs count as term URIs); `@ndes/pipeline-tn-enrich` for label denormalisation at projection time; future Knowledge Graph voor Termen.
+
+**Dataset Knowledge Graph (DKG)** *(cross-listed; see [Knowledge Graph APIs](#knowledge-graph-apis) above)*
+
+- **Canonical NDE-operated instance:** DKG – analyses dataset descriptions across substrate A.
+- **Currently exceptional among network services:** the [planned migration to QLever + blue/green](https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph/issues/298) would make it the first network service whose internals are built on Stack components.
+- **Self-operated scenarios:** a regional aggregator wanting dataset-level analytics over its own member registry; a research project profiling a curated subset; sector-specific catalogue quality dashboards.
+
+### Patterns applied at this layer
+
+The Data Layer is the primary home for most operational patterns defined in the [Patterns chapter](../patterns.md):
+
+- [Discovery via DCAT-AP Registry](../patterns.md#discovery-via-dcat-ap-registry) – the [Dataset Register](../../services/dataset-register/) is the authoritative “which datasets should exist?” signal; every rebuild starts here.
+- [Augmented Dataset Selection](../patterns.md#augmented-dataset-selection) – combine publisher-declared DCAT-AP with pipeline-derived analysis to drive selection.
+- [Blue/green Rebuild](../patterns.md#bluegreen-rebuild) – atomic dual-instance rebuild (engine-native / directory-level / proxy-level variants).
+- [Last-known-good Per-source Caching](../patterns.md#last-known-good-per-source-caching) – survive transient source outages by persisting each source’s last-good projection.
+
+Cross-cutting patterns that also apply at this layer:
+
+- [SCHEMA-AP-NDE-first](../patterns.md#schema-ap-nde-first) – Data Layer reads SCHEMA-AP-NDE without per-source mapping.
+- [Parallel Data Models](../patterns.md#parallel-data-models) – projections may consume publisher data in any of several models.
+- [Enrichments-as-Datasets](../patterns.md#enrichments-as-datasets) – Data Layer produces enrichments and publishes them back into the Dataset Register.
+- [Stable API Contract](../patterns.md#stable-api-contract) – Data Layer’s outward face; the unit of stability across rebuilds.
+
+## Presentation Layer
+
+User-facing presentation: querying the Data Layer’s API and rendering for human consumption. [Functions 9–10](#function-mapping) of [*Van data naar dienst*](https://zenodo.org/records/17541400). The Stack’s presentation-layer content is currently thin – mostly a contract description plus future work on reusable components.
+
+### Patterns applied at this layer
+
+- [Stable API Contract](../patterns.md#stable-api-contract) – the Data Layer exposes a typed, versioned API; Presentation Layers consume it without source-specific mapping. Cross-data-layer interoperability flows from this combined with SCHEMA-AP-NDE-first.
+- [SCHEMA-AP-NDE-first](../patterns.md#schema-ap-nde-first) – the data shape the Presentation Layer reads through the API.
+
+### Future work
+
+The Presentation Layer is also where the report’s development agenda is most ambitious: it asks the NDE programme to develop reusable presentation components against the gedragsprofielen (behavioural profiles). The Stack does not yet have content here. Sketched directions:
+
+- **`@ndes/heritage-ui-components`** *(future)* – a library of standardised weergavetype (display-type) components (beeldweergave, multimedia, tijdlijn, kaart, verhaal) driven by gedragsprofielen, packaged so Service Platforms and consumer applications can embed them. Initial exploration in MakeMyFlix and Erfgoedflix. NLMaps (Kadaster) is a similar inspiration for the map weergavetype.
+- **Gedragsprofielen-driven UIs** – ongoing NDE work on gedragsprofielen yields explicit data and presentation requirements per profile (Gericht informatie zoeken, Browsen en ontdekken, Intens beleven, …). Future Stack guidance will name conventions for matching components to profiles.
+- **[Function 10](#function-mapping) (Present metadata)** is empty in the function-mapping table for the same reason: presentation components are not Stack-internal yet. When they land they fill that row.

--- a/docs/stack/layers/provider.md
+++ b/docs/stack/layers/provider.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 1
+---
+
+# Data Provider side
+
+:::warning Draft – under review
+Part of the Stack documentation ([overview](../index.md)). Not yet endorsed by NDE.
+:::
+
+Data management and Publication are run by [Data Providers](../../glossary.md#data-provider). Data management is source-internal and out of scope here. Publication is the source-side externalisation that turns internal data into something the network can consume.
+
+## Publication Layer
+
+[Data Providers](../../glossary.md#data-provider) make their data available via standardised channels so [Service Platforms](../../glossary.md#service-platform), [consumers](../../glossary.md#consumer), and [network services](../../services/index.md) can discover, fetch, and process it.
+
+### Patterns applied at this layer
+
+The Publication Layer is the source-side of several cross-cutting patterns defined in the [Patterns chapter](../patterns.md):
+
+- [SCHEMA-AP-NDE-first](../patterns.md#schema-ap-nde-first): the inter-layer data contract; every Data Provider publishes at least SCHEMA-AP-NDE.
+- [Parallel Data Models](../patterns.md#parallel-data-models): publish in SCHEMA-AP-NDE and, where relevant, in one or more domain models (Linked Art, RiC-O, RDA, EDM) alongside.
+- [Enrichments-as-Datasets](../patterns.md#enrichments-as-datasets): when a Service Platform publishes its own enrichments back into the Dataset Register, those enrichments enter this layer as new published datasets.
+
+### Standards used at this layer
+
+The Publication Layer is built on standards published outside this Stack documentation. Each links to its canonical source.
+
+- **[SCHEMA-AP-NDE](https://github.com/netwerk-digitaal-erfgoed/schema-profile)**: the NDE-Schema.org-toepassingsprofiel. Network minimum for heritage data publication.
+- **Linked Open Data**: dataset publication as Turtle / N-Triples / JSON-LD dump or SPARQL endpoint. See [Publish linked data](../../publish/linked-data.md).
+- **[LDES](https://semiceu.github.io/LinkedDataEventStreams/)**: incremental change feed. Currently the most mature mechanism for sub-dataset-granularity change detection.
+- **[IIIF](https://iiif.io/)**: Image API + Presentation API for image-based heritage. See [Publish IIIF](../../publish/iiif.md).
+- **DCAT-AP 3.0 / Schema.org Dataset** – the dataset-description vocabularies the [Dataset Register](../../services/dataset-register/) accepts. Data Providers publish descriptions in either; Schema.org Dataset is the more common choice in practice, DCAT-AP is the EU-catalog-interoperability standard.
+
+### Network services consumed at this layer
+
+- **[NDE Dataset Register](../../services/dataset-register/)** – every Publication-layer dataset gets registered here. See [Register datasets](../../publish/register.md).
+- **[NDE Network of Terms](../../services/network-of-terms/)** – Data Providers ideally link to canonical terms during publication, so Service Platforms receive already-enriched data. See [Publish with terms](../../publish/terms.md).

--- a/docs/stack/patterns.md
+++ b/docs/stack/patterns.md
@@ -1,0 +1,442 @@
+---
+sidebar_position: 4
+---
+
+# Patterns
+
+:::warning Draft – under review
+Part of the Stack documentation ([overview](./index.md)). Not yet endorsed by NDE.
+:::
+
+This chapter consolidates the **operational patterns** the [Stack](index.md) uses.
+Each pattern carries an **Applies to** line indicating which of the four [layers](layers/) it touches.
+Several patterns are cross-cutting so listing them per layer would duplicate; they are listed here once and referenced from the layer pages.
+
+The patterns roughly group into three:
+
+- **Network-wide commitments** that hold across multiple layers: [SCHEMA-AP-NDE-first](#schema-ap-nde-first), [Parallel Data Models](#parallel-data-models), [Stable API Contract](#stable-api-contract), [Enrichments-as-Datasets](#enrichments-as-datasets).
+- **Data-layer operational mechanics** for rebuilding, refreshing, and surviving source-side flakiness: [Discovery via DCAT-AP Registry](#discovery-via-dcat-ap-registry), [Augmented Dataset Selection](#augmented-dataset-selection), [Change-driven Rebuild](#change-driven-rebuild), [Blue/green Rebuild](#bluegreen-rebuild), [In-place Rebuild](#in-place-rebuild), [Last-known-good Per-source Caching](#last-known-good-per-source-caching).
+- **Architectural meta-patterns** underlying the Stack as a whole: [Configurable Pipeline](#configurable-pipeline), [Ports & Adapters](#adapters).
+
+## Pattern relationships
+
+Patterns rarely stand alone; their relationships are part of what makes them load-bearing. The map below shows the main ones – which patterns pair, which compose, which require which, and which are alternatives.
+
+```mermaid
+flowchart TB
+    subgraph META ["Meta-patterns"]
+        direction LR
+        CP["Configurable<br/>Pipeline"]
+        PA["Ports &<br/>Adapters"]
+    end
+
+    subgraph NW ["Network-wide commitments"]
+        direction TB
+        SAP["SCHEMA-AP-NDE-first"]
+        PDM["Parallel<br/>Data Models"]
+        SAC["Stable API<br/>Contract"]
+        EAD["Enrichments-<br/>as-Datasets"]
+    end
+
+    subgraph DL ["Data Layer mechanics"]
+        direction TB
+        DISC["Discovery via<br/>DCAT-AP Registry"]
+        ADS["Augmented<br/>Dataset Selection"]
+        CDR["Change-driven<br/>Rebuild"]
+        BGR["Blue/green<br/>Rebuild"]
+        IPR["In-place<br/>Rebuild"]
+        LKG["Last-known-good<br/>Caching"]
+    end
+
+    %% Meta-patterns
+    CP -- requires --> PA
+
+    %% Network-wide
+    SAP -- pairs --> SAC
+    SAP -- extended by --> PDM
+
+    %% Data layer
+    DISC -- refined by --> ADS
+    DISC -- feeds --> CDR
+    CDR -- composes with --> BGR
+    CDR -- composes with --> IPR
+    BGR -- requires --> LKG
+    BGR <-- alternatives --> IPR
+
+    %% Closing the loop
+    ADS -- publishes VoID via --> EAD
+    EAD -- registered in --> DISC
+
+```
+
+The architectural meta-patterns *(Configurable Pipeline, Ports & Adapters)* are shown at the top because they underpin every operational pattern below them rather than composing with any single *operational* one. The two are not independent, though: the Configurable Pipeline is **built on** Ports & Adapters – a pipeline *contains* its ports (the Writer, engine, registry-client and reverse-proxy boundaries) and a deployment is configured by choosing which adapter fills each (QLever at the triplestore port; `SparqlUpdateWriter` or `FileWriter` at the sink; Typesense or Elasticsearch at the search engine). That structural dependency is the `requires` edge above. Configurable Pipeline is instantiated by every pipeline; Ports & Adapters underpins every adapter-backed substitution (engines, writers, registries, reverse proxies, the IIIF contract on the Stable API Contract surface).
+
+Relationship vocabulary used in the diagram:
+
+- **pairs**: peer composition – both patterns are needed together to deliver the architectural property (SCHEMA-AP-NDE-first defines the data; Stable API Contract defines the surface).
+- **extended by**: one pattern is the network minimum; the other allows richer alternatives alongside it.
+- **refined by**: one pattern adds analytical signal on top of another. Augmented Dataset Selection, for instance, adds [VoID](https://www.w3.org/TR/void/) (Vocabulary of Interlinked Datasets) analyses on top of Discovery.
+- **feeds**: one pattern's output becomes another's input.
+- **composes with**: optional combination – either pattern works on its own, both together unlock a configuration.
+- **requires**: hard dependency – the upstream pattern cannot deliver its property without the downstream.
+- **alternatives**: choose one or the other for the same axis (Blue/green vs In-place at the Deploy axis).
+- **publishes back via** / **registered in**: closes a loop – an output of one pattern becomes a published input the other discovers.
+
+## SCHEMA-AP-NDE-first
+
+*Applies to: [Publication Layer](layers/provider.md#publication-layer), [Data Layer](layers/platform.md#data-layer).*
+
+The [NDE Schema.org Application Profile](https://docs.nde.nl/schema-profile/) is the data contract between what Data Providers produce and what Service Platforms consume:
+
+- every Data Provider publishes at least SCHEMA-AP-NDE ([Publication Layer](layers/provider.md#publication-layer) commitment)
+- every Service Platform can read SCHEMA-AP-NDE without per-source mapping work ([Data Layer](layers/platform.md#data-layer) expectation),
+
+Pairs with [Stable API Contract](#stable-api-contract). SCHEMA-AP-NDE-first defines *what* the data looks like across layers; Stable API contract defines *how* the Data Layer exposes it through a stable API. The two compose: SCHEMA-AP-NDE-first is the data contract; Stable API contract is the API engineering on top.
+
+#### Mechanics
+
+- Data Providers publish SCHEMA-AP-NDE-conformant [linked data](../glossary.md#linked-data) (RDF dump, SPARQL, and/or LDES). Validation against the  [netwerk-digitaal-erfgoed/schema-profile](https://github.com/netwerk-digitaal-erfgoed/schema-profile) SHACL is the conformance check.
+  The [Dataset Knowledge Graph](../services/dataset-knowledge-graph) automatically reports conformance.
+- The `@lde/*` core stays data-model-agnostic – generic linked-data plumbing. The `@ndes/*` configuration layer carries SCHEMA-AP-NDE-specific shapes and annotations (e.g., `@ndes/schema-profile-search-config`), making SCHEMA-AP-NDE the network default. A deployment configures a different data model by swapping in a different `@ndes/<other-model>-…-config` package.
+- The [Dataset Register](../services/dataset-register/) carries `dcterms:conformsTo` pointing at SCHEMA-AP-NDE for every NDE-compatible dataset.
+
+#### Why this matters
+
+SCHEMA-AP-NDE acts as a **pivot**: a shared intermediate shape every party maps to and from, like a pivot language in translation.
+
+- **The pivot collapses an O(n×m) integration problem to O(n+m).** Without it, every Service Platform needs a per-source mapping. With it, *n* Data Providers × *m* Service Platforms all interoperate through one shape.
+- **Network-wide search becomes possible.** Cross-collection search works because every record arrives in the same shape. The pivot is what makes a network rather than a federation of bilateral integrations.
+
+#### Tradeoffs
+
+- **The profile is a minimum, not the full picture.** SCHEMA-AP-NDE is intentionally narrow and will not cover the full expressive range of GLAM data. Sources with rich domain semantics still need a parallel domain model: see [Parallel Data Models](#parallel-data-models).
+- **Versioning the pivot affects the whole network.** A breaking change in SCHEMA-AP-NDE ripples to every Data Provider, Service Platform, and Presentation Layer.
+
+## Parallel Data Models
+
+*Applies to: [Publication Layer](layers/provider.md#publication-layer), [Data Layer](layers/platform.md#data-layer). The flexibility layer above the [SCHEMA-AP-NDE-first](#schema-ap-nde-first) pivot: same data, multiple model expressions, served alongside each other.*
+
+> Voor linked data-systemen is het gebruikelijk dezelfde informatie in meerdere datamodellen aan te bieden, zodat deze eenvoudig gecombineerd of afzonderlijk kan worden opgevraagd. ([_Van data naar dienst_](https://zenodo.org/records/17541400) p. 25)
+
+Same data, multiple orthogonal model expressions, served alongside each other and consumable separately or combined. 
+[SCHEMA-AP-NDE](#schema-ap-nde-first) is the network minimum; [domain-specific models](../glossary.md#data-model) coexist where relevant.
+
+#### Mechanics
+
+- Each data model is **its own SHACL shape graph**, not unioned with others. A dataset advertises multiple `dcterms:conformsTo` values.
+- Downstream tooling reads whichever shape suits: the Search pipeline’s AP-aware projection gets one `search:` annotations package per data model (`@ndes/schema-profile-search-config`, future `@ndes/linked-art-search-config`, etc.) – not merged.
+- A single dataset can be served in multiple representations either [combined or separated](https://docs.nde.nl/schema-profile/#publication-method).
+- Consumers pick which model they want via [profile-based content negotiation](https://docs.nde.nl/schema-profile/#profiles), query parameter, or simply by hitting the right endpoint.
+
+#### Why this matters
+
+- Different consumers want different vocabularies. A web developer building a discovery UI wants `schema:CreativeWork`; a museum specialist wants `crm:E22_Human-Made_Object`. Forcing one onto the other loses precision in one direction and accessibility in the other.
+- Reach beats parsimony at the network level. The cost of multiple representations is paid back in audience – including European delivery via EDM, which is otherwise a separate transformation step.
+
+#### Tradeoffs
+
+- **Storage and maintenance cost** scales with the number of models.
+- **Update discipline:** the same source change must propagate to all model expressions or they drift. Easier when generated from a shared internal representation than maintained in parallel.
+
+## Stable API Contract
+
+*Applies to: [Data Layer](layers/platform.md#data-layer), [Presentation Layer](layers/platform.md#presentation-layer). The contract surface the Data Layer exposes to Presentation Layers; the unit of stability across rebuilds, deployments, and consumer rollouts.*
+
+> Een volgende ontwikkelstap is om de presentatielaag volledig los te zien van het dienstplatform. ([_Van data naar dienst_](https://zenodo.org/records/17541400) p. 17)
+
+Every Data Layer commits to **at least** the shared API contracts the Stack standardises (GraphQL for typed search, REST for versioned resource access, SPARQL for graph queries, [IIIF](https://iiif.io/) for image-based heritage – the latter externally maintained by the IIIF community, see below), each typed and backward-compatible. Because these contracts are identical across Data Layers, a Presentation Layer can pull from its own Data Layer, from another, or compose from several at once.
+
+A Data Layer may additionally expose specialised or optimised APIs alongside the shared contracts – they live in the Data Layer because they need direct data access. These specialised APIs are deployment-specific and need not interoperate across Data Layers. What the shared contracts keep out is presentation-specific fields on the shared types (see the *No presentation-specific fields* mechanic and the *Discipline cost* tradeoff below).
+
+The Data Layer is ignorant of specific presentations at the shared-contract level. The shared contracts are what stay stable when the data is rebuilt, the Data Layer is redeployed, or new consumers attach.
+
+Pairs with [SCHEMA-AP-NDE-first](#schema-ap-nde-first). Stable API contract is about the *API engineering*: typed evolution, multi-consumer affordances, versioning discipline. SCHEMA-AP-NDE-first is about the *data model* the API exposes. Both are needed: SCHEMA-AP-NDE-first without API discipline gives a consistent vocabulary served through an unstable interface; API discipline without SCHEMA-AP-NDE-first gives a versioned interface to per-source vocabularies that don't compose.
+
+Not every stable contract is Stack-defined. The [IIIF Presentation API](https://iiif.io/api/presentation/) and [Image API](https://iiif.io/api/image/) are externally specified, versioned, and committed to backward compatibility by the IIIF community; when the Stack serves IIIF, it adopts an externally-determined stable contract rather than designing its own. The pattern applies the same way – typed surface, additive evolution, multi-consumer affordances – just maintained by IIIF rather than by NDE.
+
+#### Mechanics
+
+- **Typed, additive evolution.** GraphQL schema with non-breaking extensions only (new fields, new optional arguments, new enum values; never removed or retyped). REST with versioned routes. SPARQL as an RDF-native escape hatch.
+- **Search and filter are part of the contract.** GraphQL exposes a typed `search(query, filter, sort, …)` field returning AP-typed results; REST exposes versioned `/search?…` plus resource collections with declared filter parameters. The set of filterable fields, the filter operators, and the result shape are all part of the schema.
+- **Multi-consumer affordances built in from day one**, even when v1 has one consumer: per-consumer rate limits, CORS allow-list per origin, API keys issuable, telemetry tagged with `presentation_layer=<id>`.
+- **Standard HTTP conventions:** status codes, `Accept-Language` for multilingual content negotiation, `Cache-Control`, ETags.
+- **Auth and abuse mitigation at the gateway**, not in the schema. The contract stays clean.
+- **No presentation-specific fields in the contract.** Types follow the AP / data model (`Dataset`, `CreativeWork`, `Place`, …), not any particular consumer’s UI needs. The contract gives you the data; the Presentation Layer shapes it for its own views – composed display titles, sized thumbnail URLs, type-keyed badges all live there, not in the shared schema.
+
+#### Why this matters
+
+- **Cross-data-layer interoperability** (the property the intro names) enables the four configurations the report sketches in ch. 3 – classic, multi-source presentation, fully-separate presentation, data-layer-only Service Platform – without per-configuration Data Layer changes. The pivot stabilises the shape; the API contract stabilises the surface.
+- Decouples the data-layer rebuild cycle from presentation rollout. The Search pipeline can rebuild hourly; the presentation can deploy weekly.
+- New Presentation Layers (an alternative UI for education, a researcher portal, a public widget) land as configuration on the Data Layer’s gateway, not as code.
+- Forces the “shaped for web devs, not RDF specialists” discipline. The contract is the audience boundary.
+
+#### Tradeoffs
+
+- **Discipline cost.** Tempting to leak presentation concerns into projections. Resist – use server-side composition instead.
+- **Versioning discipline is harder than ad-hoc evolution.** Every change needs the non-breaking lens applied.
+- **Multi-consumer affordances cost something** even when only one consumer exists. Pay it anyway – retrofit is expensive.
+
+## Discovery via DCAT-AP Registry
+
+*Applies to: [Data Layer](layers/platform.md#data-layer).*
+
+> Datasetregister gebruiken voor het opvragen van de bronnen ([_Van data naar dienst_](https://zenodo.org/records/17541400) p. 19)
+
+A DCAT-AP registry (in the NDE network: the [Dataset Register](../services/dataset-register/)) is the **authoritative “which datasets exist?” signal**.
+It contains dataset descriptions provided by Data Providers.
+Stack components never hardcode a source list; every [pipeline](#configurable-pipeline) starts by discovering datasets from the registry.
+
+#### Mechanics
+
+- [`@lde/dataset-registry-client`](https://github.com/ldelements/lde/tree/main/packages/dataset-registry-client) queries the registry, returning a stream of `dcat:Dataset` descriptions with their distributions. Generic over DCAT-AP 3.0 registries; not tied to the NDE Dataset Register specifically.
+- **Filtered queries narrow the candidate list at discovery time.** Pipelines can ask the registry for datasets matching criteria – keyword, publisher, subject, `dcterms:conformsTo`, validity – rather than fetching the full list and filtering downstream. The NDE [Dataset Register](../services/dataset-register/) exposes this via its [SPARQL endpoint](../services/dataset-register/sparql.md) (arbitrary filter expressions) and a [website search](https://datasetregister.netwerkdigitaalerfgoed.nl/en/datasets) for human use.
+
+#### Why this matters
+
+- All Stack [pipelines](pipeline.md) use the same discovery step; no per-component source-list configuration.
+- It is the basis for [Last-known-good Caching](#last-known-good-per-source-caching) (the cache lifecycle is keyed on registry membership, not on previous index state).
+- A source removed from the registry drops out everywhere downstream on the next rebuild, automatically. A source added shows up everywhere. Operationally clean.
+
+## Augmented Dataset Selection
+
+*Applies to: [Data Layer](layers/platform.md#data-layer). Refines [Discovery via DCAT-AP Registry](#discovery-via-dcat-ap-registry) with derived analyses (VoID statistics) on top of publisher-declared metadata.*
+
+> Op basis van beschrijvingen in het Datasetregister en de beschikbare linked data bij de bron kunnen
+inhoudelijke analyses worden gemaakt van de informatie. ([_Van data naar dienst_](https://zenodo.org/records/17541400) p. 22)
+
+Selection decisions improve when two *kinds* of metadata are combined: what the publisher **declares** about a dataset (DCAT-AP description in the registry) and what an automated pipeline **derives** by analysing the data itself (VoID statistics: triple counts, class partitions, property partitions, language partitions). Each is partial; together they let a consumer decide whether a dataset is worth ingesting, in full or sampled, and against which projection logic.
+
+#### Mechanics
+
+- **Declared metadata:** DCAT-AP description fetched via [`@lde/dataset-registry-client`](https://github.com/ldelements/lde/tree/main/packages/dataset-registry-client) (per [Discovery](#discovery-via-dcat-ap-registry) above).
+- **Derived metadata:** [`@lde/pipeline-void`](https://github.com/ldelements/lde/tree/main/packages/pipeline-void) analyses the dataset’s SPARQL endpoint or dump and produces a VoID description. Output is RDF; can be cached per-dataset, diffed across runs, and published.
+- **Selection logic reads both sides:**
+  - Skip datasets whose declared `dcterms:conformsTo` doesn’t include a relevant AP or data model.
+  - Skip datasets whose VoID class partitions don’t contain target classes.
+  - Sample stratified by class size when VoID indicates the dataset is too large for full ingestion.
+  - Skip re-processing when the VoID hash is unchanged since last run.
+- **Network artifact.** Derived VoID is generated once and published so other consumers can read it instead of re-analysing – as the [Dataset Knowledge Graph](../services/dataset-knowledge-graph) does today. This closes the same loop as [Enrichments-as-Datasets](#enrichments-as-datasets), but for analytical metadata rather than content enrichment.
+
+#### Why this matters
+
+- **Declared metadata alone is incomplete.** Data Providers publish what they think matters; rich DCAT-AP descriptions still can’t tell you “this dataset has 12 instances of `crm:E22` but 50 000 of `crm:E21`.”
+- **Derived metadata alone is too expensive to compute per consumer.** Every Service Platform analysing every dataset wastes compute; centralising the analysis amortises the cost.
+- **Combination gives selection logic real signal.** A pipeline can refuse to ingest a dataset that *says* it conforms to SCHEMA-AP-NDE but whose VoID shows zero `schema:` predicates – an inconsistency the declared side alone wouldn’t catch.
+
+#### Tradeoffs
+
+- **Derivation cost.** Computing VoID requires walking the dataset. Centralising it in DKG amortises the cost; per-platform analysis multiplies it.
+- **Freshness mismatch.** Declared metadata and derived analysis can drift apart. Treat the two as one combined snapshot; re-derive when either side moves.
+- **Partition granularity is fixed by the VoID vocabulary.** Finer-grained selection needs custom extensions.
+
+## Enrichments-as-Datasets
+
+*Applies to: [Publication Layer](layers/provider.md#publication-layer), [Data Layer](layers/platform.md#data-layer). Service Platforms publish their enrichments as separate datasets, feeding them back into the network as new published sources.*
+
+Enrichments produced inside a [Service Platform](../glossary.md#service-platform) (term links, georeferences, transcriptions, user annotations) are not consumed only locally. They are published as standalone datasets in the [Dataset Register](../services/dataset-register/) and become network-level inputs that other Service Platforms can discover and consume. The Service Platform’s outputs close the loop back into the network.
+
+#### Mechanics
+
+- **Standard models:** [Web Annotation Data Model](https://www.w3.org/TR/annotation-model/) for the enrichment content, [PROV-O](https://www.w3.org/TR/prov-o/) for provenance.
+- **Provenance triples:** each enrichment carries `dcterms:source` (the enriched dataset’s URI) and `prov:wasDerivedFrom` (the source records / activities).
+- **Published as a separate `dcat:Dataset`**, with its own distribution(s) – SPARQL endpoint, dump, or LDES feed (`@lde/ldes-static-writer` once available).
+- **Registered in the [Dataset Register](../services/dataset-register/)** so the [Discovery pattern](#discovery-via-dcat-ap-registry) picks it up automatically network-wide.
+
+#### Why this matters
+
+- A term link produced by one platform becomes term knowledge for the whole network – feeds the Term Backlink Graph, feeds other Service Platforms, feeds vocab curators.
+- Source data + Service Platform enrichments together can be re-aggregated by anyone; the enrichments are no longer trapped behind a single UI.
+- Provenance is preserved; downstream consumers see *who* enriched *what*, *when*, *derived from what*.
+
+#### Tradeoffs
+
+- Storage and serving cost for an additional dataset.
+- Versioning discipline: a re-enrichment after a vocab update is a new version, not a silent overwrite.
+- Discoverability depends on consumers actually subscribing to the enrichment LDES.
+- Some enrichments derive mechanically from term URIs and do not need to be published separately.
+
+## Change-driven Rebuild
+
+*Applies to: [Data Layer](layers/platform.md#data-layer). Filters the candidate dataset list to only sources whose data has changed since the last run.*
+
+> Wijzigingen bij de bron leidend maken voor het bijwerken van de opgenomen informatie ([_Van data naar dienst_](https://zenodo.org/records/17541400) p. 19)
+
+A rebuild that re-processes every source on every run wastes work and floods upstream endpoints. Change-driven rebuild runs downstream stages *only* for sources whose data has actually changed since the last run. [Discovery](#discovery-via-dcat-ap-registry) produces the candidate list; this pattern filters it.
+
+Composes with both deploy strategies. With [Blue/green Rebuild](#bluegreen-rebuild), unchanged sources land in the new build via [Last-known-good Per-source Caching](#last-known-good-per-source-caching) – the same cache that Blue/green already needs for source-outage resilience. With [In-place Rebuild](#in-place-rebuild), unchanged sources stay where they are because the rebuild only touches changed ones; no cache needed.
+
+The granularity of "what changed" varies. LDES gives record-level deltas including deletions — true incremental. Per-record timestamps (`schema:sdDatePublished`) let a consumer filter for records newer than its last-seen max, so additions and updates are record-level even without LDES — though pure deletions go undetected. Distribution-level signals (`Last-Modified`, declared metadata, fingerprint) only say "the dataset changed somehow"; without per-record timestamps to layer on top, the response is a full per-dataset re-crawl (which does catch deletions).
+
+#### Mechanics
+
+Change-detection mechanisms, in order of precision:
+
+- **Sub-dataset change feeds.** LDES streams individual record-level changes. Most precise; no whole-dataset re-processing.
+- **Per-distribution conditional probes.** [`@lde/distribution-probe`](https://github.com/ldelements/lde/tree/main/packages/distribution-probe) HEADs each HTTP distribution and reads `Last-Modified` / `ETag`. Cheap and well-supported for dumps; SPARQL endpoints rarely expose comparable change signals.
+- **Per-record timestamps.** For SCHEMA-AP-NDE-conformant sources, a `SELECT (MAX(?sd) AS ?max) WHERE { ?cw schema:sdDatePublished ?sd }` aggregate returns the dataset’s most recent [record-publication time](https://docs.nde.nl/schema-profile/#CreativeWork-sdDatePublished). Cheap on most stores (aggregate only, no result-set walk); works on SPARQL endpoints and dumps alike. Catches additions and updates; misses pure deletions.
+- **Distribution timestamp.** The distribution’s last-modified date as declared by the publisher.
+- **Content fingerprint.** Hash a downloaded source dump and compare against the previous run’s fingerprint. Cheap for dumps; impractical for SPARQL endpoints, where walking the data costs as much as re-processing.
+
+A rebuild runs downstream stages only for sources whose change signal has advanced since the last run; unchanged sources reuse their previous projection from [Last-known-good Caching](#last-known-good-per-source-caching).
+
+Pipelines pick the mechanism based on what each source supports: LDES where the publisher offers it; `Last-Modified` for HTTP dumps; `MAX(?sdDatePublished)` for SCHEMA-AP-NDE-conformant SPARQL endpoints; content-fingerprint for dumps without `Last-Modified`; declared metadata or scheduled full re-processing for non-conformant SPARQL endpoints.
+
+#### Why this matters
+
+- **Compute, bandwidth, and source-side load all drop** with each more-precise mechanism. LDES on a busy dataset can mean processing thousands of small deltas instead of a terabyte-scale full crawl.
+- **Composes with the other Data-layer patterns.** [Discovery](#discovery-via-dcat-ap-registry) produces the dataset list; this pattern filters it by change signal; [Augmented Dataset Selection](#augmented-dataset-selection) filters it by AP-conformance and VoID partitions; [Blue/green Rebuild](#bluegreen-rebuild) ships the result; [Last-known-good Caching](#last-known-good-per-source-caching) carries unchanged sources.
+
+#### Tradeoffs
+
+- **Depends on Data Providers publishing accurate change signals.** LDES adoption is sparser still.
+- **Fingerprinting is a fallback, not a default.** Computing a fingerprint requires walking the source – cheaper than re-processing but not free. Use it only when upstream signals are unreliable.
+- **Coarser signals miss intra-dataset changes.** A dataset’s last-modified date may advance without revealing which records changed; downstream sinks then re-process the whole dataset even if only one record actually moved.
+- **SPARQL-only sources without AP-conformance are the hard case.** Without LDES, accurate registry metadata, or AP-mandated per-record timestamps (`schema:sdDatePublished`), no reliable automated change detection. Fallback: scheduled full re-processing at whatever cadence the consumer can afford.
+
+A pipeline can optionally consume LDES from a [Change Stream Producer](layers/platform.md#change-stream-producer) instead of running these mechanisms per-source itself. The Producer centralises the same mechanisms once for its own scope and exposes a uniform LDES feed; consumers that opt in get a single input contract regardless of how the underlying sources publish. Use of a Producer is per-deployment and per-source, not all-or-nothing.
+
+## Blue/green Rebuild
+
+*Applies to: [Data Layer](layers/platform.md#data-layer). Atomic dual-instance rebuild for derived stores. **Requires [Last-known-good Per-source Caching](#last-known-good-per-source-caching)** for source-outage resilience: without it, any source unreachable during the rebuild disappears from the new build. Alternative to [In-place Rebuild](#in-place-rebuild); composes with [Change-driven Rebuild](#change-driven-rebuild) on top.*
+
+Atomic dual-instance rebuild without infrastructure-level access (no kubectl, no Kubernetes service swap). The rebuild pipeline does the flip itself.
+
+Blue/green fans the rebuild out per source, then ships the result via the swap. Two complications fall out of that fan-out, both solved by the same cache:
+
+- **Source-outage resilience.** Any source can be temporarily unreachable during a run. Without per-source state, that source vanishes from the new build at swap time. [Last-known-good Per-source Caching](#last-known-good-per-source-caching) keeps the previous projection on disk; the rebuild reads the union of fresh + cached projections, and the swap ships a complete build.
+- **Composition with Change-driven Rebuild.** If [Change-driven Rebuild](#change-driven-rebuild) skips unchanged sources, those sources still need to land in the new build – they come from the same Last-known-good cache.
+
+Both complications resolve through one mechanism, so Last-known-good is the operational sibling of Blue/green, with or without Change-driven on top.
+
+#### Mechanics
+
+Three variants, distinguished by *what gets flipped* (engine alias, filesystem symlink, reverse-proxy upstream):
+
+**Engine-native** – the engine has a built-in collection/index alias API.
+
+- Typesense: `collections/alias` swap; used by the Search pipeline.
+- The pipeline rebuilds into a fresh collection, calls the engine’s alias API, drops the old. Zero downtime, no proxy.
+
+**Directory-level** – the engine has no alias API but loads from a directory; restart is fast.
+
+- QLever: `qlever index` builds into `index-new/` while the live server keeps serving from `current/`. Atomic symlink swap (`current/` → `index-new/`) followed by `qlever restart`. Downtime = restart window (seconds).
+- Default for QLever-backed components (e.g. the planned Term Backlink Graph; dump-source ingestion in the Search pipeline).
+
+**Proxy-level** – two engine instances on different ports, a reverse proxy in front holds the “live” upstream pointer.
+
+- Pipeline loads into the inactive instance; once healthy, the proxy atomically swaps which upstream is live (nginx reload, HAProxy runtime API, Caddy admin API, etc.).
+- Zero downtime, *and* institutional self-containment: when the reverse proxy is bundled inside the application’s own deployment, the entire swap mechanism lives within the app’s control. No dependency on foundational infra the heritage institution may not have permission to change.
+- Default proxy is nginx; any reverse proxy supporting atomic upstream switching works.
+
+Pick the cheapest variant the consumer’s latency requirements *and* the deployment environment’s permissions allow. Heritage-institution deployments may prefer proxy-level even when directory-level would suffice on latency grounds, because it removes infra-cooperation requirements.
+
+#### Why this matters
+
+- **Zero-downtime atomic switch.** Reads against the live store continue while the new build is materialised; the swap is a single atomic operation. No half-rebuilt window.
+- **Structurally right for snapshot-source deletions.** A pipeline reading periodic dumps has to ingest the whole dump to detect deletions: there is no way to learn “record X is gone” without confirming X isn’t in the new dump. A full rebuild via alias-swap pays no extra cost relative to incremental approaches – the dump-read cost is paid in both. The “skip unchanged resources” win that incremental processing seems to offer only saves the projection step, not the read. For snapshot sources without LDES, blue/green is one structurally right answer to the delete problem.
+- **Composes with [Change-driven Rebuild](#change-driven-rebuild).** Full alias-swap where unchanged sources reuse cached projections via [Last-known-good Caching](#last-known-good-per-source-caching). Alternatively replace with [In-place Rebuild](#in-place-rebuild) – accepting source-scoped atomicity in exchange for skipping the rebuild cost on stable sources. Pick by deployment shape and source-cadence divergence.
+
+#### Tradeoffs
+
+- **Full rebuild every run.** Even when only one source changed, the alias-swap variant rebuilds the whole derived store. For divergent source cadences, [In-place Rebuild](#in-place-rebuild) is the cheaper alternative.
+- **Variant choice constrained by sink.** Engine-native is cheapest but needs an alias API. Directory-level needs a fast restart. Proxy-level needs operational permission to run a reverse proxy. The variant table above is the matching exercise.
+- **Brief restart window in Directory-level.** QLever-style symlink + restart variants are not zero-downtime; the restart window is the cost.
+
+## In-place Rebuild
+
+*Applies to: [Data Layer](layers/platform.md#data-layer). Alternative to [Blue/green Rebuild](#bluegreen-rebuild) for sinks where re-projecting all sources every run is wasteful and source cadences diverge.*
+
+Modify the live sink in place: upsert per-source documents with `source` and `last_seen` fields (set to `run_start` on every upsert), then sweep – delete any document whose `last_seen < run_start` for this source. No atomic swap; reads against the live sink see a mix of fresh and stale documents during the sweep window.
+
+#### Mechanics
+
+- Each document carries `source: <dataset-URI>` and `last_seen: <ISO timestamp>`.
+- At the start of a run, capture `run_start`. For each source whose change signal has advanced (per [Change-driven Rebuild](#change-driven-rebuild)): bulk upsert all current records with `last_seen = run_start`, then `DELETE WHERE source = X AND last_seen < run_start`.
+- Sources whose signal hasn’t advanced are skipped entirely.
+
+#### Why this matters
+
+- **Diverging source cadences.** When some sources change hourly and others yearly, a full rebuild on every run is mostly wasted I/O. In-place per-source updates let each source’s pipeline run on its own cadence.
+- **No full-rebuild cost.** Skipped sources cost zero; touched sources cost only their own re-projection.
+- **Last-known-good is implicit.** The live sink doubles as per-source state: any source whose change signal hasn’t advanced has its documents (and `source` + `last_seen` markers) preserved in place. No separate cache directory needed – the sink *is* the cache, and that's why [Last-known-good Per-source Caching](#last-known-good-per-source-caching) is not required alongside In-place (unlike [Blue/green Rebuild](#bluegreen-rebuild), where the fresh build starts empty).
+
+#### Tradeoffs
+
+- **Source-scoped atomicity only.** During a per-source rebuild there is a brief window where the sink has some upserted-fresh and some pre-sweep stale documents from the same source. Reads in that window are inconsistent. Acceptable for typical consumer use but a real semantics change from [Blue/green Rebuild](#bluegreen-rebuild)’s atomic swap.
+- **Per-document state cost.** Every doc carries two extra fields (`source`, `last_seen`). Cheap, but a schema commitment.
+- **Deletions via sweep, not events.** A deleted record disappears because it is not re-upserted; the sink cannot tell whether it was deleted or just temporarily missing. (LDES would distinguish.)
+- **Requires upsert + delete-by-filter at the sink.** Most engines support this (Typesense, Elasticsearch, SPARQL stores) but not all – engines that load read-only after build, like QLever, cannot.
+
+## Last-known-good Per-source Caching
+
+*Applies to: [Data Layer](layers/platform.md#data-layer). Sibling to [Blue/green Rebuild](#bluegreen-rebuild). Resilience for transient source-side outages during a rebuild.*
+
+A rebuild that fans out per source can fail for some sources without losing their previous data. Each source’s projection is materialised to its own file; if the source is unreachable this run, the existing file persists and is picked up by the rebuild’s downstream steps unchanged. The registry (see [Discovery](#discovery-via-dcat-ap-registry)) is the authority on whether the dataset should still exist; reachability is just whether *this run* refreshes it.
+
+#### Mechanics
+
+- Use [`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline)’s `FileWriter` with `format: 'n-quads'` or another framework-supported format. Each source writes to a deterministic path: `<cache-dir>/<filenamified-iri>.<ext>`.
+- For each `dcat:Dataset` in the registry:
+  - If endpoint reachable: re-run the projection stages, overwriting the cache file (atomically, via temp-write + rename).
+  - If unreachable: leave the existing cache file in place. Log the staleness.
+- Rebuild’s downstream step (`qlever index <cache-dir>/*.nq`, or Typesense bulk import, or whichever sink) reads the union of fresh + cached files. It can’t tell the difference – they are just files.
+- A source removed from the registry: drop its cache file on the next rebuild.
+- **Staleness threshold** (configurable per deployment): drop a source’s cache file after N consecutive failed probes or after M days of unreachability. Default: 30 days. Protects against permanently-broken endpoints silently lingering forever.
+
+#### Why this matters
+
+- **Survives transient source outages.** A single unreachable source doesn’t lose its data or stall the rebuild – the previous projection stays in place until the source comes back.
+- **Decouples rebuild scope from per-source reachability.** Reachability becomes a per-run signal, not a registry-membership signal. The registry decides whether a dataset should exist; reachability only decides whether *this run* refreshes it.
+- **Closes a gap the report describes only implicitly.** [Function 6](layers/platform.md#function-mapping)’s “afgeleide of cache”-framing taken literally would lose unreachable sources during a rebuild; this pattern keeps them.
+
+#### Tradeoffs
+
+- **Disk usage.** Full N copies of source projections persist; for substrate B at NDE-network scale this can be substantial.
+- **Schema evolution.** Cached files from a previous run encode the schema in use *then*. After a SHACL or `search:` annotation change, cached files may be stale-shaped, not just stale-content. Default policy: invalidate the entire cache directory on annotation-graph change.
+- **Trend analysis is still a separate concern.** Caching keeps the *current* state resilient; it does not preserve historical observations for trend analysis. That needs an explicit historical store or an LDES feed.
+
+## Configurable Pipeline
+
+*Applies to: cross-cutting (all layers). Engineering meta-pattern alongside [Ports & Adapters](#adapters). Fully described in the [Pipeline](pipeline.md) chapter; named here as a pattern so other patterns and components can reference it. Instantiated by every Data Layer pipeline: [Search Pipeline](layers/platform.md#search-pipeline), [Knowledge Graph Pipeline](layers/platform.md#knowledge-graph-pipeline), [Change Stream Producer](layers/platform.md#change-stream-producer).*
+
+Data Layer pipelines are **configured, not coded**. Pipeline structure is explicit in configuration artifacts (SHACL shapes for projection, SPARQL CONSTRUCT for extraction, JSON-LD Frames for output shaping) not buried inside bespoke scripts.
+Custom code lives only at [port/adapter](#adapters) boundaries (a writer, a filter compiler). The contrast is with implicit, coded pipelines whose stages, transformations, and assumptions are visible only to the people maintaining the code.
+
+See [Pipeline](pipeline.md) for the configuration axes, composition rules, and worked examples.
+
+## Ports & Adapters {#adapters}
+
+*Applies to: cross-cutting (all layers). Engineering meta-pattern – the architectural commitment behind the [Foundational technologies](index.md#foundational-technologies) substitutes column and the Stack’s claim that defaults are exchangeable.*
+
+Engineering meta-pattern that forms the commitment behind the [Foundational technologies](index.md#foundational-technologies) substitutes column and the Stack’s claim that defaults are exchangeable.
+
+The Stack follows **ports-and-adapters**: core logic depends on **ports** (abstract interfaces), and concrete tools attach as **adapters** behind those ports. 
+This is what makes the Stack’s “Realistic substitutes” claim real: substitution is a configuration concern, not a code rewrite.
+
+#### Mechanics
+
+- **Define a narrow port**: the minimum operational interface (the contract) and a clean argument type (the data flowing across it). For the Search Pipeline, the port is *“index the documents you are given and serve typed queries against them”*; its argument is the engine-agnostic framed document, not raw SHACL. This decouples adapters from SHACL: every adapter receives the framed document and only worries about engine specifics. For a KG, the port is *“load these triples and serve SPARQL”*; argument is `.nq`. For a registry, *“discover datasets matching a query”*; argument is a typed query.
+- **Implement adapters per concrete backend.** Each adapter translates between port and backend specifics. Filter compilers (GraphQL → Typesense `filter_by` vs Elasticsearch query DSL) live in the adapter, not the port.
+- **Default selection is configuration, not code.** A deployment names its adapter choice in a config file; the pipeline composes the rest.
+- **Adapter graduation.** As more deployments use an alternative adapter, it can graduate from “realistic substitute” to “additionally supported default.”
+
+Concrete instances in the Stack:
+
+- **Search engine.** The [Search pipeline](layers/platform.md#data-layer) defines a generic engine-agnostic schema and a typed filter input language; the Typesense adapter is the v1 implementation. Elasticsearch and OpenSearch can plug into the same port with their own adapter, sharing the AP-aware projection logic upstream.
+- **KG triplestore.** [Knowledge graphs](layers/platform.md#data-layer) build into any SPARQL-compliant store. QLever is the Stack default (its read-only-after-load lifecycle fits [blue/green rebuild](#bluegreen-rebuild)); Oxigraph, GraphDB, and Jena Fuseki are adapter alternatives.
+- **Per-source writer.** [`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline) defines a `Writer` port with several adapters: `FileWriter` (n-quads / Turtle to disk – the default for blue/green rebuilds), `SparqlUpdateWriter` (the original DKG approach), more to come. Pipelines depend on `Writer`, not on a specific output sink.
+- **Reverse proxy.** The proxy-level [blue/green rebuild](#bluegreen-rebuild) variant treats nginx, HAProxy, and Caddy as adapters behind the same “atomic upstream swap” port.
+- **DCAT-AP registry.** [Discovery via DCAT-AP Registry](#discovery-via-dcat-ap-registry) – [`@lde/dataset-registry-client`](https://github.com/ldelements/lde/tree/main/packages/dataset-registry-client) is generic over any DCAT-AP 3.0 catalog; the NDE Dataset Register is one instance; a self-operated catalog is another.
+- **Network services as categories.** Each network service entry on the [Data Layer page](layers/platform.md#data-layer) is structured as a category (the port) with a canonical NDE-operated instance and optional self-operated instances (adapters). Same shape, applied at the operated-service level.
+
+#### Why this matters
+
+- **Substitutability is real, not aspirational.** “Use Typesense by default but Elasticsearch if needed” only works when the dependence is on a port, not on Typesense specifically. Without ports-and-adapters, swap claims become rewrites.
+- **Deployments choose their own dependencies.** Heritage institutions with operational constraints (no Node.js, no QLever, no nginx, no public NDE Dataset Register) can adapt without forking. A self-operated Stack deployment substitutes for institutional reasons; a research deployment substitutes for performance reasons; both use the same pattern.
+- **Vendor lock-in is bounded.** No Stack component is married to a specific backend. The cost of moving off Typesense or QLever is one adapter, not a rewrite.
+
+#### Tradeoffs
+
+- **Indirection cost.** Ports add an abstraction layer; reading a code path requires understanding both port and adapter.
+- **Abstraction discipline.** Ports must be narrow enough that alternative adapters are realistic to write. A port that leaks too much backend specifics (e.g., baking in Typesense’s filter syntax) defeats the pattern.
+- **Adapter maintenance.** Each supported adapter is a maintenance cost. The Stack commits to defaults; alternatives are “supported on best-effort” unless promoted.

--- a/docs/stack/pipeline.md
+++ b/docs/stack/pipeline.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 5
+---
+
+# Pipeline
+
+:::warning Draft – under review
+Part of the Stack documentation ([overview](./index.md)). Not yet endorsed by NDE.
+:::
+
+## Why pipelines
+
+Pipelines are how the [Data Layer](layers/platform.md#data-layer) gets built. Every derived product – search indexes, knowledge graphs, term mappings, dataset analyses – is produced by a pipeline that reads from sources, projects the data into a target shape, and materialises it into a sink. The Stack’s [substrates](index.md#substrates) (A, B, C) are inputs; pipelines turn them into outputs.
+
+Different Data Layer products share most of the work: every pipeline runs the same [stages](#stages) – discover, select, read, project, validate, materialise, serve – diverging only from **Project** onward, where the target shape takes over. Pipelines factor these stages so each product is built by **composing the same primitives** differently. The [patterns](patterns.md) chapter names the operational mechanics individually; this chapter shows how they compose into a working pipeline.
+
+The Stack standardises on **standards-backed pipelines** – SHACL for shape constraints, SPARQL for extraction, JSON-LD Framing for output reshaping – instead of bespoke Python scripts. Each pipeline is configured by declarative linked-data standards, not by custom transformation code. This is what makes pipelines portable across deployments, lets the same SHACL drive both the build and the API contract, and keeps the system inspectable: each stage’s input and output is RDF that any standards-compliant tool can read.
+
+## `@lde/pipeline`
+
+[`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline) is the Stack’s orchestration framework. Pipelines compose **Executors** (stages that read, transform, validate, or project RDF) and **Writers** (sinks that materialise output: files, SPARQL stores, search engines). Every Data Layer pipeline – the [Search Pipeline](layers/platform.md#search-pipeline), knowledge-graph building, Term Backlink Graph – is `@lde/pipeline` configured differently.
+
+This chapter names the **configuration axes** a pipeline picks along, and shows how the [patterns](patterns.md) slot into each axis. A builder picks one option per axis; the choices interact in known ways.
+
+## Stages
+
+Every Data Layer pipeline runs the same spine of seven stages from source to served API. A pipeline is *built* over stages 1–6 and *serves* at stage 7. Each [configuration axis](#configuration-axes) attaches to one stage; the per-pipeline examples below expand the stages where they specialise.
+
+| # | Stage | What it does | Configured by |
+| --- | --- | --- | --- |
+| 1 | **Discover** | Obtain the candidate source list | [Discovery](#configuration-axes) axis |
+| 2 | **Select** | Filter to the sources worth ingesting | [Selection](#configuration-axes) axis |
+| 3 | **Read** | Load source RDF – all selected sources, or only changed | [Scope](#configuration-axes) axis |
+| 4 | **Project** | Transform source RDF into the target shape | the specialisation point – no axis |
+| 5 | **Validate** | SHACL-check the projection and handle violations | [Validation](#configuration-axes) axis |
+| 6 | **Materialise & deploy** | Write to the sink and make it live | [Deploy](#configuration-axes) axis; [State](#configuration-axes) axis pairs with it |
+| 7 | **Serve** *(query-time)* | Expose the typed API | derived from the projection contract – no axis |
+
+Stages 1–3 are shared upstream; pipelines diverge from **Project** onward, where the target shape determines validation, sink, and API. The [Search Pipeline](layers/platform.md#search-pipeline) expands stages 4–7 into finer [phases](layers/platform.md#pipeline-phases); the [Knowledge Graph](layers/platform.md#knowledge-graph-pipeline) and [EDM export](#example-edm-export-loda-pipeline) pipelines expand them differently.
+
+## Configuration axes
+
+| Axis | Question | Options                                                    | Patterns |
+| --- | --- |------------------------------------------------------------| --- |
+| **Discovery** | Where does the source list come from? | <ul><li>DCAT-AP registry</li><li>static config</li></ul>   | [Discovery via DCAT-AP Registry](patterns.md#discovery-via-dcat-ap-registry) |
+| **Selection** | Which discovered sources to ingest? | <ul><li>Declared metadata only</li><li>Declared + VoID-derived</li></ul> | [Augmented Dataset Selection](patterns.md#augmented-dataset-selection) |
+| **Scope** | Which selected sources does each run process? | <ul><li>All selected sources</li><li>Only changed sources</li></ul> | [Change-driven Rebuild](patterns.md#change-driven-rebuild) |
+| **Validation** | How is the projection checked, and what happens to violations? | <ul><li>Reuse projection SHACL (search)</li><li>Separate target shapes (EDM)</li><li>Sampled profile (DKG)</li></ul>; policy: fail / drop / report / sample | [Non-conformant source data](layers/platform.md#non-conformant-source-data) |
+| **Deploy** | How does the result land in the sink? | <ul><li>Blue/green swap</li><li>In-place upsert + sweep</li></ul> | [Blue/green Rebuild](patterns.md#bluegreen-rebuild), [In-place Rebuild](patterns.md#in-place-rebuild) |
+| **State** | What carries between runs? | <ul><li>Nothing</li><li>Per-source projection cache</li><li>Per-doc `last_seen`</li></ul> | [Last-known-good Per-source Caching](patterns.md#last-known-good-per-source-caching) |
+
+Source input may be the source itself (with the pipeline running its own change detection) or an upstream LDES feed from a [Change Stream Producer](layers/platform.md#change-stream-producer). Both feed the Projection step the same way; the choice is per-deployment.
+
+## Composing the axes
+
+The axes are mostly independent. The one meaningful interaction:
+
+- **Scope × Deploy.** *Change-driven + Blue/green* needs [Last-known-good Caching](patterns.md#last-known-good-per-source-caching) so unchanged sources can reuse their previous projection during a full alias swap. *Change-driven + In-place* needs per-doc `last_seen` state for the sweep. *Full-scope + Blue/green* is the simplest configuration: re-project every source every run, no per-source state.
+
+## Example: Search pipeline
+
+Scope and State below are expressed as the search pipeline’s named **update modes** – [Mode 1](layers/platform.md#update-modes) (full rebuild, the default), Mode 2 (per-source incremental, designed-in but not yet active), Mode 3 (per-resource, future):
+
+| Axis | Choice |
+| --- | --- |
+| Discovery | DCAT-AP registry (Dataset Register) |
+| Selection | Augmented (declared `dcterms:conformsTo` + VoID class partitions) |
+| Scope | Full today (Mode 1); change-driven planned (Mode 2/3) |
+| Validation | Reuse projection SHACL – the [SHACL-honest](layers/platform.md#non-conformant-source-data) policy (validator rules = indexer decisions) |
+| Deploy | Blue/green – Typesense alias swap |
+| State | None today (Mode 1); per-doc `source` + `last_seen` designed in for Mode 2 |
+
+## Example: Term Backlink Graph (proposed)
+
+| Axis | Choice |
+| --- | --- |
+| Discovery | DCAT-AP registry (Dataset Register) |
+| Selection | Declared metadata only – any RDF source, no AP-conformance filter |
+| Scope | Full re-projection per run (until LDES adoption broadens) |
+| Validation | None – data-model-agnostic walk, no shapes to conform to |
+| Deploy | Blue/green – QLever directory-level swap |
+| State | Per-source projection cache via [Last-known-good Caching](patterns.md#last-known-good-per-source-caching) |
+
+The choice differences encode the structural difference between the two pipelines: the Search pipeline is AP-aware (drives a SHACL projection against SCHEMA-AP-NDE); the Term Backlink Graph is data-model-agnostic (walks any RDF for term URI references). The axis structure is the same.
+
+## Example: EDM export (loda-pipeline)
+
+[`loda-pipeline` (PR #14)](https://github.com/netwerk-digitaal-erfgoed/loda-pipeline/pull/14) projects heritage datasets into [EDM](https://pro.europeana.eu/page/edm-documentation) for aggregation into Europeana. It is a downstream consumer of [SCHEMA-AP-NDE-first](patterns.md#schema-ap-nde-first): it maps the **SCHEMA-AP-NDE pivot to EDM**, so a single mapping covers every source instead of one mapping per source data model. EDM export runs today on legacy LD Workbench; the `@lde/pipeline` + QLever migration in that PR is what makes it a Stack-conformant pipeline and is not yet on `main`. The axis choices below describe that migrated pipeline.
+
+| Axis | Choice |
+| --- | --- |
+| Discovery | DCAT-AP registry (Dataset Register), filtering out already-transformed EDM distributions |
+| Selection | Datasets published in SCHEMA-AP-NDE – the pivot shape is the mapping’s input contract |
+| Scope | Full re-projection per run |
+| Validation | Separate EDM shapes – report violations and continue |
+| Deploy | EDM output for Europeana aggregation (file artifact, not a live sink swap) |
+| State | None |
+
+Projection is **SPARQL CONSTRUCT mapping SCHEMA-AP-NDE to EDM**, not a reshaping of the [framed document](layers/platform.md#architecture-two-stage-split): each dataset’s SCHEMA-AP-NDE is imported into QLever and CONSTRUCTed into EDM, then SHACL-validated against EDM shapes. Per-dataset CONSTRUCTs are split into separate executors (e.g. `edm:ProvidedCHO` + aggregation + constants) joined by `UNION` rather than `OPTIONAL`, so multi-valued properties don’t multiply into cross-product duplicates. The axis structure is the same as the Search and KG pipelines, aimed at a third target shape.
+
+## When to extend the axis set
+
+A new axis is warranted when a real choice opens up that the existing axes don’t capture. Candidates to keep an eye on:
+
+- **Trigger axis** (push: webhooks, [LDN](https://www.w3.org/TR/ldn/) (Linked Data Notifications)) when network sources begin to offer push notifications. Today every pipeline is pull-based and scheduled, so the trigger is a constant rather than a choice; the *Scope* axis above covers the only real lever (process all selected sources vs. only changed ones). A separate Trigger axis lands the day push arrives.
+- **Cross-pipeline event publishing** (an upstream substrate-B pipeline that fans out to per-projection consumers) – currently aspirational; would warrant a *Distribution* axis if built.
+
+Until those land, the six axes above cover the configurations the Stack actually deploys today.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,7 +4,11 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
-const config: Config = {
+export default async function createConfig(): Promise<Config> {
+  // remark-deflist is ESM-only; load it via dynamic import inside the async config function.
+  const remarkDeflist = (await import('remark-deflist')).default;
+
+  const config: Config = {
   title: 'NDE',
   tagline: 'Make digital heritage accessible to all',
   favicon: 'img/favicon.png',
@@ -76,6 +80,7 @@ const config: Config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
+          remarkPlugins: [remarkDeflist],
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
@@ -191,6 +196,7 @@ const config: Config = {
       additionalLanguages: ['turtle', 'sparql'],
     },
   } satisfies Preset.ThemeConfig,
-};
+  };
 
-export default config;
+  return config;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "graphiql": "^5.2.3",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.2.6",
-        "react-dom": "^19.2.6"
+        "react-dom": "^19.2.6",
+        "remark-deflist": "^1.0.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.1",
@@ -9436,6 +9437,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -14867,6 +14877,15 @@
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -17837,6 +17856,545 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-deflist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-deflist/-/remark-deflist-1.0.0.tgz",
+      "integrity": "sha512-sDHM+ZbgWC6wwaxltMdH5x+XYMW8VpjyeHyC2ZCI106+iYgbPv8lBYKiNqdW0Cs0FVox/LysYhb3qIZe1b0cmg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.1.1",
+        "mdast-util-to-string": "^3.1.0",
+        "unist-util-visit": "^4.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/@types/mdast": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
+      "integrity": "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/remark-deflist/node_modules/mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/remark-deflist/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-deflist/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-directive": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
@@ -18239,6 +18797,18 @@
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -19953,6 +20523,33 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uvu/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/value-equal": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "graphiql": "^5.2.3",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "remark-deflist": "^1.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -83,6 +83,7 @@ a[class*="tagWithCount_"]:hover {
 .markdown p a,
 .markdown li a,
 .markdown td a,
+.markdown dd a,
 .markdown blockquote a {
   color: inherit;
   text-decoration: underline;
@@ -93,10 +94,12 @@ a[class*="tagWithCount_"]:hover {
 .markdown p a:hover,
 .markdown li a:hover,
 .markdown td a:hover,
+.markdown dd a:hover,
 .markdown blockquote a:hover,
 .markdown p a:focus-visible,
 .markdown li a:focus-visible,
 .markdown td a:focus-visible,
+.markdown dd a:focus-visible,
 .markdown blockquote a:focus-visible {
   color: var(--ifm-link-color);
 }
@@ -201,6 +204,31 @@ article a[aria-label^="Read more"]:hover {
 
 article a[aria-label^="Read more"] b {
   font-weight: inherit;
+}
+
+/* Definition lists (rendered via remark-deflist) — term and definition side-by-side. */
+.markdown dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 0.5rem;
+  row-gap: 0.15rem;
+  margin: 1rem 0;
+  align-items: baseline;
+}
+
+.markdown dl dt {
+  font-weight: 700;
+  grid-column: 1;
+  text-align: right;
+}
+
+.markdown dl dt::after {
+  content: ":";
+}
+
+.markdown dl dd {
+  grid-column: 2;
+  margin: 0;
 }
 
 article a[aria-label^="Read more"]::after {


### PR DESCRIPTION
## Summary

Introduces the **Stack** chapter (`docs/stack/`) — proposed engineering choices, naming conventions, and operational patterns for the NDE network, operationalising the architecture from *Van data naar dienst* (NDE, November 2025). Marked draft / under review. Six new doc files, plus the build change needed to render them.

## What the chapter introduces

**Overview (`index.md`)** — defines the *NDE Stack* as the ecosystem of NDE-compatible components plus the operational patterns that compose them. Establishes a shared taxonomy (Component, Pattern, Service, Network service, Standard, Foundational technology), a Components catalog, the foundational technologies the Stack builds on (QLever, Typesense, nginx, Fastify, Mercurius) with realistic substitutes, and the three source **substrates** (A: dataset descriptions, B: dataset contents, C: terminology sources) that every pipeline rides on.

**Layers (`layers/`)** — the four-layer model and per-layer guidance:
- `layers/index.md` — the four layers (Data management, Publication, Data Layer, Presentation) and how the Stack composes LDE (`@lde/*`) packages with NDE-specific configuration (`@ndes/*`).
- `layers/provider.md` — **Data Provider side**: the Publication Layer, the standards published there (SCHEMA-AP-NDE, LDES, IIIF, DCAT-AP 3.0 / Schema.org Dataset), and the network services consumed.
- `layers/platform.md` — **Service Platform side**: a function-mapping table of the report's ten functions onto existing/proposed components, then the Data Layer components (Search Pipeline, Search APIs, Knowledge Graph Pipeline, Knowledge Graph APIs, Change Stream Producer, Network Services) and the Presentation Layer. Includes the two-stage SHACL-driven search architecture, the framed-document model, update modes, and consumption modes.

**Patterns (`patterns.md`)** — the operational patterns the Stack uses, with a relationship map and per-pattern *Applies to* scope: SCHEMA-AP-NDE-first, Parallel Data Models, Stable API Contract, Discovery via DCAT-AP Registry, Augmented Dataset Selection, Enrichments-as-Datasets, Change-driven Rebuild, Blue/green Rebuild, In-place Rebuild, Last-known-good Per-source Caching, Configurable Pipeline, and Ports & Adapters.

**Pipeline (`pipeline.md`)** — how Data Layer pipelines are configured rather than coded: the shared seven-stage spine, the configuration axes (Discovery, Selection, Scope, Validation, Deploy, State), composition rules, and worked examples (Search pipeline, Term Backlink Graph, EDM export).

## Build & styling change

The Component blocks use Markdown definition-list syntax, which Docusaurus does not render on its own. This PR:
- adds the **`remark-deflist`** plugin and wires it into the docs preset (loaded via dynamic import since it is ESM-only, which makes the config an async function);
- styles the resulting `<dl>` blocks in `custom.css` (term and definition side-by-side, trailing colon, standard link colours).
