### PR TITLE
docs: move Glossary to last menu item, after Stack

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Glossary


### PR DESCRIPTION
Bump the Glossary’s `sidebar_position` from `8` to `9` so it sorts after Stack and becomes the last item in the top-level menu.

New top-level order:

1. Introduction
2. The NDE landscape
3. Use datasets
4. Publish datasets
5. Build software
6. Services
7. Requirements
8. Stack
9. Glossary
