### PR TITLE
docs(stack): rename pipeline stage Project to Transform

### DIFF
--- a/docs/stack/pipeline.md
+++ b/docs/stack/pipeline.md
@@ -10,15 +10,15 @@ Part of the Stack documentation ([overview](./index.md)). Not yet endorsed by ND
 
 ## Why pipelines
 
-Pipelines are how the [Data Layer](layers/platform.md#data-layer) gets built. Every derived product – search indexes, knowledge graphs, term mappings, dataset analyses – is produced by a pipeline that reads from sources, projects the data into a target shape, and materialises it into a sink. The Stack’s [substrates](index.md#substrates) (A, B, C) are inputs; pipelines turn them into outputs.
+Pipelines are how the [Data Layer](layers/platform.md#data-layer) gets built. Every derived product – search indexes, knowledge graphs, term mappings, dataset analyses – is produced by a pipeline that reads from sources, transforms the data into a target shape, and materialises it into a sink. The Stack’s [substrates](index.md#substrates) (A, B, C) are inputs; pipelines turn them into outputs.
 
-Different Data Layer products share most of the work: every pipeline runs the same [stages](#stages) – discover, select, read, project, validate, materialise, serve – diverging only from **Project** onward, where the target shape takes over. Pipelines factor these stages so each product is built by **composing the same primitives** differently. The [patterns](patterns.md) chapter names the operational mechanics individually; this chapter shows how they compose into a working pipeline.
+Different Data Layer products share most of the work: every pipeline runs the same [stages](#stages) – discover, select, read, transform, validate, materialise, serve – diverging only from **Transform** onward, where the target shape takes over. Pipelines factor these stages so each product is built by **composing the same primitives** differently. The [patterns](patterns.md) chapter names the operational mechanics individually; this chapter shows how they compose into a working pipeline.
 
 The Stack standardises on **standards-backed pipelines** – SHACL for shape constraints, SPARQL for extraction, JSON-LD Framing for output reshaping – instead of bespoke Python scripts. Each pipeline is configured by declarative linked-data standards, not by custom transformation code. This is what makes pipelines portable across deployments, lets the same SHACL drive both the build and the API contract, and keeps the system inspectable: each stage’s input and output is RDF that any standards-compliant tool can read.
 
 ## `@lde/pipeline`
 
-[`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline) is the Stack’s orchestration framework. Pipelines compose **Executors** (stages that read, transform, validate, or project RDF) and **Writers** (sinks that materialise output: files, SPARQL stores, search engines). Every Data Layer pipeline – the [Search Pipeline](layers/platform.md#search-pipeline), knowledge-graph building, Term Backlink Graph – is `@lde/pipeline` configured differently.
+[`@lde/pipeline`](https://github.com/ldelements/lde/tree/main/packages/pipeline) is the Stack’s orchestration framework. Pipelines compose **Executors** (stages that read, transform, or validate RDF) and **Writers** (sinks that materialise output: files, SPARQL stores, search engines). Every Data Layer pipeline – the [Search Pipeline](layers/platform.md#search-pipeline), knowledge-graph building, Term Backlink Graph – is `@lde/pipeline` configured differently.
 
 This chapter names the **configuration axes** a pipeline picks along, and shows how the [patterns](patterns.md) slot into each axis. A builder picks one option per axis; the choices interact in known ways.
 
@@ -31,12 +31,12 @@ Every Data Layer pipeline runs the same spine of seven stages from source to ser
 | 1 | **Discover** | Obtain the candidate source list | [Discovery](#configuration-axes) axis |
 | 2 | **Select** | Filter to the sources worth ingesting | [Selection](#configuration-axes) axis |
 | 3 | **Read** | Load source RDF – all selected sources, or only changed | [Scope](#configuration-axes) axis |
-| 4 | **Project** | Transform source RDF into the target shape | the specialisation point – no axis |
-| 5 | **Validate** | SHACL-check the projection and handle violations | [Validation](#configuration-axes) axis |
+| 4 | **Transform** | Convert source RDF into the target shape | the specialisation point – no axis |
+| 5 | **Validate** | SHACL-check the output and handle violations | [Validation](#configuration-axes) axis |
 | 6 | **Materialise & deploy** | Write to the sink and make it live | [Deploy](#configuration-axes) axis; [State](#configuration-axes) axis pairs with it |
-| 7 | **Serve** *(query-time)* | Expose the typed API | derived from the projection contract – no axis |
+| 7 | **Serve** *(query-time)* | Expose the typed API | derived from the transformation contract – no axis |
 
-Stages 1–3 are shared upstream; pipelines diverge from **Project** onward, where the target shape determines validation, sink, and API. The [Search Pipeline](layers/platform.md#search-pipeline) expands stages 4–7 into finer [phases](layers/platform.md#pipeline-phases); the [Knowledge Graph](layers/platform.md#knowledge-graph-pipeline) and [EDM export](#example-edm-export-loda-pipeline) pipelines expand them differently.
+Stages 1–3 are shared upstream; pipelines diverge from **Transform** onward, where the target shape determines validation, sink, and API. The [Search Pipeline](layers/platform.md#search-pipeline) expands stages 4–7 into finer [phases](layers/platform.md#pipeline-phases); the [Knowledge Graph](layers/platform.md#knowledge-graph-pipeline) and [EDM export](#example-edm-export-loda-pipeline) pipelines expand them differently.
 
 ## Configuration axes
 
@@ -45,17 +45,17 @@ Stages 1–3 are shared upstream; pipelines diverge from **Project** onward, whe
 | **Discovery** | Where does the source list come from? | <ul><li>DCAT-AP registry</li><li>static config</li></ul>   | [Discovery via DCAT-AP Registry](patterns.md#discovery-via-dcat-ap-registry) |
 | **Selection** | Which discovered sources to ingest? | <ul><li>Declared metadata only</li><li>Declared + VoID-derived</li></ul> | [Augmented Dataset Selection](patterns.md#augmented-dataset-selection) |
 | **Scope** | Which selected sources does each run process? | <ul><li>All selected sources</li><li>Only changed sources</li></ul> | [Change-driven Rebuild](patterns.md#change-driven-rebuild) |
-| **Validation** | How is the projection checked, and what happens to violations? | <ul><li>Reuse projection SHACL (search)</li><li>Separate target shapes (EDM)</li><li>Sampled profile (DKG)</li></ul>; policy: fail / drop / report / sample | [Non-conformant source data](layers/platform.md#non-conformant-source-data) |
+| **Validation** | How is the transformation checked, and what happens to violations? | <ul><li>Reuse transformation SHACL (search)</li><li>Separate target shapes (EDM)</li><li>Sampled profile (DKG)</li></ul>; policy: fail / drop / report / sample | [Non-conformant source data](layers/platform.md#non-conformant-source-data) |
 | **Deploy** | How does the result land in the sink? | <ul><li>Blue/green swap</li><li>In-place upsert + sweep</li></ul> | [Blue/green Rebuild](patterns.md#bluegreen-rebuild), [In-place Rebuild](patterns.md#in-place-rebuild) |
-| **State** | What carries between runs? | <ul><li>Nothing</li><li>Per-source projection cache</li><li>Per-doc `last_seen`</li></ul> | [Last-known-good Per-source Caching](patterns.md#last-known-good-per-source-caching) |
+| **State** | What carries between runs? | <ul><li>Nothing</li><li>Per-source transformation cache</li><li>Per-doc `last_seen`</li></ul> | [Last-known-good Per-source Caching](patterns.md#last-known-good-per-source-caching) |
 
-Source input may be the source itself (with the pipeline running its own change detection) or an upstream LDES feed from a [Change Stream Producer](layers/platform.md#change-stream-producer). Both feed the Projection step the same way; the choice is per-deployment.
+Source input may be the source itself (with the pipeline running its own change detection) or an upstream LDES feed from a [Change Stream Producer](layers/platform.md#change-stream-producer). Both feed the Transform step the same way; the choice is per-deployment.
 
 ## Composing the axes
 
 The axes are mostly independent. The one meaningful interaction:
 
-- **Scope × Deploy.** *Change-driven + Blue/green* needs [Last-known-good Caching](patterns.md#last-known-good-per-source-caching) so unchanged sources can reuse their previous projection during a full alias swap. *Change-driven + In-place* needs per-doc `last_seen` state for the sweep. *Full-scope + Blue/green* is the simplest configuration: re-project every source every run, no per-source state.
+- **Scope × Deploy.** *Change-driven + Blue/green* needs [Last-known-good Caching](patterns.md#last-known-good-per-source-caching) so unchanged sources can reuse their previous transformation during a full alias swap. *Change-driven + In-place* needs per-doc `last_seen` state for the sweep. *Full-scope + Blue/green* is the simplest configuration: re-transform every source every run, no per-source state.
 
 ## Example: Search pipeline
 
@@ -66,7 +66,7 @@ Scope and State below are expressed as the search pipeline’s named **update mo
 | Discovery | DCAT-AP registry (Dataset Register) |
 | Selection | Augmented (declared `dcterms:conformsTo` + VoID class partitions) |
 | Scope | Full today (Mode 1); change-driven planned (Mode 2/3) |
-| Validation | Reuse projection SHACL – the [SHACL-honest](layers/platform.md#non-conformant-source-data) policy (validator rules = indexer decisions) |
+| Validation | Reuse transformation SHACL – the [SHACL-honest](layers/platform.md#non-conformant-source-data) policy (validator rules = indexer decisions) |
 | Deploy | Blue/green – Typesense alias swap |
 | State | None today (Mode 1); per-doc `source` + `last_seen` designed in for Mode 2 |
 
@@ -76,33 +76,33 @@ Scope and State below are expressed as the search pipeline’s named **update mo
 | --- | --- |
 | Discovery | DCAT-AP registry (Dataset Register) |
 | Selection | Declared metadata only – any RDF source, no AP-conformance filter |
-| Scope | Full re-projection per run (until LDES adoption broadens) |
+| Scope | Full re-transformation per run (until LDES adoption broadens) |
 | Validation | None – data-model-agnostic walk, no shapes to conform to |
 | Deploy | Blue/green – QLever directory-level swap |
-| State | Per-source projection cache via [Last-known-good Caching](patterns.md#last-known-good-per-source-caching) |
+| State | Per-source transformation cache via [Last-known-good Caching](patterns.md#last-known-good-per-source-caching) |
 
-The choice differences encode the structural difference between the two pipelines: the Search pipeline is AP-aware (drives a SHACL projection against SCHEMA-AP-NDE); the Term Backlink Graph is data-model-agnostic (walks any RDF for term URI references). The axis structure is the same.
+The choice differences encode the structural difference between the two pipelines: the Search pipeline is AP-aware (drives a SHACL transformation against SCHEMA-AP-NDE); the Term Backlink Graph is data-model-agnostic (walks any RDF for term URI references). The axis structure is the same.
 
 ## Example: EDM export (loda-pipeline)
 
-[`loda-pipeline` (PR #14)](https://github.com/netwerk-digitaal-erfgoed/loda-pipeline/pull/14) projects heritage datasets into [EDM](https://pro.europeana.eu/page/edm-documentation) for aggregation into Europeana. It is a downstream consumer of [SCHEMA-AP-NDE-first](patterns.md#schema-ap-nde-first): it maps the **SCHEMA-AP-NDE pivot to EDM**, so a single mapping covers every source instead of one mapping per source data model. EDM export runs today on legacy LD Workbench; the `@lde/pipeline` + QLever migration in that PR is what makes it a Stack-conformant pipeline and is not yet on `main`. The axis choices below describe that migrated pipeline.
+[`loda-pipeline` (PR #14)](https://github.com/netwerk-digitaal-erfgoed/loda-pipeline/pull/14) transforms heritage datasets into [EDM](https://pro.europeana.eu/page/edm-documentation) for aggregation into Europeana. It is a downstream consumer of [SCHEMA-AP-NDE-first](patterns.md#schema-ap-nde-first): it maps the **SCHEMA-AP-NDE pivot to EDM**, so a single mapping covers every source instead of one mapping per source data model. EDM export runs today on legacy LD Workbench; the `@lde/pipeline` + QLever migration in that PR is what makes it a Stack-conformant pipeline and is not yet on `main`. The axis choices below describe that migrated pipeline.
 
 | Axis | Choice |
 | --- | --- |
 | Discovery | DCAT-AP registry (Dataset Register), filtering out already-transformed EDM distributions |
 | Selection | Datasets published in SCHEMA-AP-NDE – the pivot shape is the mapping’s input contract |
-| Scope | Full re-projection per run |
+| Scope | Full re-transformation per run |
 | Validation | Separate EDM shapes – report violations and continue |
 | Deploy | EDM output for Europeana aggregation (file artifact, not a live sink swap) |
 | State | None |
 
-Projection is **SPARQL CONSTRUCT mapping SCHEMA-AP-NDE to EDM**, not a reshaping of the [framed document](layers/platform.md#architecture-two-stage-split): each dataset’s SCHEMA-AP-NDE is imported into QLever and CONSTRUCTed into EDM, then SHACL-validated against EDM shapes. Per-dataset CONSTRUCTs are split into separate executors (e.g. `edm:ProvidedCHO` + aggregation + constants) joined by `UNION` rather than `OPTIONAL`, so multi-valued properties don’t multiply into cross-product duplicates. The axis structure is the same as the Search and KG pipelines, aimed at a third target shape.
+The transformation is **SPARQL CONSTRUCT mapping SCHEMA-AP-NDE to EDM**, not a reshaping of the [framed document](layers/platform.md#architecture-two-stage-split): each dataset’s SCHEMA-AP-NDE is imported into QLever and CONSTRUCTed into EDM, then SHACL-validated against EDM shapes. Per-dataset CONSTRUCTs are split into separate executors (e.g. `edm:ProvidedCHO` + aggregation + constants) joined by `UNION` rather than `OPTIONAL`, so multi-valued properties don’t multiply into cross-product duplicates. The axis structure is the same as the Search and KG pipelines, aimed at a third target shape.
 
 ## When to extend the axis set
 
 A new axis is warranted when a real choice opens up that the existing axes don’t capture. Candidates to keep an eye on:
 
 - **Trigger axis** (push: webhooks, [LDN](https://www.w3.org/TR/ldn/) (Linked Data Notifications)) when network sources begin to offer push notifications. Today every pipeline is pull-based and scheduled, so the trigger is a constant rather than a choice; the *Scope* axis above covers the only real lever (process all selected sources vs. only changed ones). A separate Trigger axis lands the day push arrives.
-- **Cross-pipeline event publishing** (an upstream substrate-B pipeline that fans out to per-projection consumers) – currently aspirational; would warrant a *Distribution* axis if built.
+- **Cross-pipeline event publishing** (an upstream substrate-B pipeline that fans out to per-transformation consumers) – currently aspirational; would warrant a *Distribution* axis if built.
 
 Until those land, the six axes above cover the configurations the Stack actually deploys today.


### PR DESCRIPTION
Renames the pipeline `Project` stage (stage 4) to `Transform` throughout `docs/stack/pipeline.md`, aligning the chapter with the `@lde/pipeline` configuration surface, where the stage is `transform`.

## Changes

- Stage 4: `Project` becomes `Transform` (Convert source RDF into the target shape).
- Dependent references updated: diverge from Transform onward, the Transform step, transformation SHACL, Per-source transformation cache, re-transform, Full re-transformation per run.
- Stage 5 description now reads SHACL-check the output, matching output-level validation.

Terminology only; no structural changes. Draft chapter, still under review.

## Why Transform, not Project

- **`project` is misleading.** In relational algebra and SPARQL, projection (π, the `SELECT` clause) means *choosing columns or variables*, not transforming data. Database- and RDF-literate readers therefore read `project` as column selection – close to the opposite of the model-to-model `CONSTRUCT` mapping this stage performs.
- **`transform` is conventional and not too narrow.** It is the Transform step of ETL, which spans both per-record mapping and aggregation: an aggregation (such as a VoID summary) is also a transformation of the source, so one term covers both the per-record and aggregate cases this stage handles.
- **It matches the chapter itself.** Stage 4 was already glossed as *transform source RDF into the target shape*, and the surrounding prose consistently speaks of *mapping*. The label now matches the description.
- **One word across doc and framework.** `@lde/pipeline` names this stage `transform` in its configuration, so the documentation and the code use the same term.

We also considered `derive` (after the *derived data* framing in *Designing Data-Intensive Applications*) but rejected it: *derive* connotes *derivative / secondary*, the wrong register for the step that produces the network-facing product.
