### PR TITLE
docs(stack): schema-fingerprint rebuild trigger + engine-dependent normalization

### DIFF
--- a/docs/stack/layers/platform.md
+++ b/docs/stack/layers/platform.md
@@ -276,6 +276,8 @@ The architectural consequence: “what if my crawled datasets speak different AP
 
 Default is Mode 1: atomic, no state, simple to reason about. Mode 2 is designed in (every document carries `source` and `last_seen` from day one) but not activated until source cadences diverge enough to make Mode 1 wasteful. Mode 3 stays out of scope until upstream LDES feeds appear.
 
+A Mode 1 full rebuild is not scheduled; it fires automatically when the [schema fingerprint](../patterns.md#rebuild-trigger-schema-fingerprint) changes – a deploy that retypes a field or bumps the fold-map – while routine runs take the incremental path. Query-time tuning (weights, synonyms, typo tolerance) is excluded from the fingerprint and synced live, so changing it never forces a rebuild.
+
 This is the engine-native variant of the [Blue/green Rebuild](../patterns.md#bluegreen-rebuild) pattern, specialised to the search engine’s collection-alias API.
 
 ##### Non-conformant source data

--- a/docs/stack/layers/platform.md
+++ b/docs/stack/layers/platform.md
@@ -234,6 +234,14 @@ Multilingual properties (`rdf:langString` / `sh:languageIn`) project as a nested
 
 This preserves per-language stemming, IDF and query-time boosting (the engine binds `locale` to a field path, not to an array element). A single multi-valued `string[]` field would lose those.
 
+##### Normalization is engine-dependent
+
+Diacritic folding and stemming are not free on every engine. Lucene-based engines (Elasticsearch, OpenSearch) fold and stem natively in their analysis chain – `asciifolding` plus a language analyzer – so the projection can hand them raw text. Typesense cannot: it auto-folds only *decomposing* diacritics for the default locale, and it cannot transliterate *non-decomposing* letters (ø, æ, ß) while also stemming Dutch. The flagship case is the register’s [diacritic-insensitive search](https://github.com/netwerk-digitaal-erfgoed/dataset-register/issues/1661) – “Møhlmann” must be found by “Mohlmann”.
+
+Where the engine cannot do it, the **application** must, under one iron rule: **fold identically at index time and query time.** Any divergence is a silent miss – a document folded one way and a query folded another never match. The Dataset Register search uses a shared, zero-dependency fold utility (proposed `@lde/text-normalization`) imported by both the indexer (index time) and the browser (query time), so the two cannot drift. Pre-folding also sidesteps Typesense’s stemming-versus-diacritics locale conflict: fold first, then let the engine stem the already-folded tokens.
+
+This is a [Ports & Adapters](../patterns.md#adapters) consequence – an engine adapter can push an obligation back up onto the projection. The fold utility is engine-driven (Lucene engines would not need it), so it belongs at the adapter boundary rather than in the engine-agnostic projection; the catch is that the same utility must also run on the query side, outside the indexing pipeline entirely.
+
 ##### Term labels: two sources, two purposes
 
 Term labels enter the index from two distinct sources, serving two distinct UI concerns:

--- a/docs/stack/patterns.md
+++ b/docs/stack/patterns.md
@@ -452,4 +452,5 @@ Concrete instances in the Stack:
 
 - **Indirection cost.** Ports add an abstraction layer; reading a code path requires understanding both port and adapter.
 - **Abstraction discipline.** Ports must be narrow enough that alternative adapters are realistic to write. A port that leaks too much backend specifics (e.g., baking in Typesense’s filter syntax) defeats the pattern.
+- **Adapters can push work back onto the core.** A narrow port hides backend specifics, but some backends lack a capability the others provide – Typesense has no `asciifolding`, so diacritic folding moves into an application-side utility that must be applied identically at index time and query time. The port stays clean; the obligation is real, and it reaches past the pipeline onto the query side. See [Normalization is engine-dependent](layers/platform.md#normalization-is-engine-dependent).
 - **Adapter maintenance.** Each supported adapter is a maintenance cost. The Stack commits to defaults; alternatives are “supported on best-effort” unless promoted.

--- a/docs/stack/patterns.md
+++ b/docs/stack/patterns.md
@@ -330,6 +330,19 @@ Three variants, distinguished by *what gets flipped* (engine alias, filesystem s
 
 Pick the cheapest variant the consumer’s latency requirements *and* the deployment environment’s permissions allow. Heritage-institution deployments may prefer proxy-level even when directory-level would suffice on latency grounds, because it removes infra-cooperation requirements.
 
+#### Rebuild trigger: schema fingerprint
+
+A full blue/green rebuild is expensive enough that firing it on a fixed schedule wastes work whenever the index shape has not changed. Fire it instead only when the **index-affecting configuration** changes, detected by a **fingerprint**: a hash over everything that determines the index’s shape and analysis – the field registry (which fields, their types, facet/sort flags), the fold-map version (folded values are *stored*, so changing the map invalidates them), and the projection / CONSTRUCT logic.
+
+Query-time parameters are deliberately **excluded** from the fingerprint: relevance weights, synonyms, typo tolerance, and default sort are applied per query against the live collection, so changing them needs no reindex – they sync live on every run instead.
+
+The fingerprint is stored as metadata on the live collection (or alias). Every run compares the code’s fingerprint against the live one:
+
+- **mismatch** → blue/green full rebuild, then done;
+- **match** → the incremental path ([In-place Rebuild](#in-place-rebuild) upsert + sweep, or a no-op).
+
+Rebuilds become **deploy-driven and automatic**: a commit that retypes a field or bumps the fold-map triggers a self-rebuild on the next scheduled run, with no cron entry and no manual flag. This is distinct from the source-change trigger ([Change-driven Rebuild](#change-driven-rebuild), which decides *which sources* a run processes); the fingerprint decides *whether the whole index must be rebuilt from scratch*.
+
 #### Why this matters
 
 - **Zero-downtime atomic switch.** Reads against the live store continue while the new build is materialised; the swap is a single atomic operation. No half-rebuilt window.

--- a/docs/stack/pipeline.md
+++ b/docs/stack/pipeline.md
@@ -102,7 +102,7 @@ The transformation is **SPARQL CONSTRUCT mapping SCHEMA-AP-NDE to EDM**, not a r
 
 A new axis is warranted when a real choice opens up that the existing axes don’t capture. Candidates to keep an eye on:
 
-- **Trigger axis** (push: webhooks, [LDN](https://www.w3.org/TR/ldn/) (Linked Data Notifications)) when network sources begin to offer push notifications. Today every pipeline is pull-based and scheduled, so the trigger is a constant rather than a choice; the *Scope* axis above covers the only real lever (process all selected sources vs. only changed ones). A separate Trigger axis lands the day push arrives.
+- **Trigger axis** (push: webhooks, [LDN](https://www.w3.org/TR/ldn/) (Linked Data Notifications)) when network sources begin to offer push notifications. Today every pipeline is pull-based and scheduled, so the trigger is a constant rather than a choice; the *Scope* axis above covers the only real lever (process all selected sources vs. only changed ones). A separate Trigger axis lands the day push arrives. This source-change trigger is orthogonal to the config-change trigger that already exists – the [schema fingerprint](patterns.md#rebuild-trigger-schema-fingerprint) that fires a full [Blue/green Rebuild](patterns.md#bluegreen-rebuild) when index-affecting configuration changes is deploy-driven, not source-driven, so it is not the Trigger axis discussed here.
 - **Cross-pipeline event publishing** (an upstream substrate-B pipeline that fans out to per-transformation consumers) – currently aspirational; would warrant a *Distribution* axis if built.
 
 Until those land, the six axes above cover the configurations the Stack actually deploys today.


### PR DESCRIPTION
## What

Two related Stack-doc gaps surfaced while reviewing the Typesense search PRD (netwerk-digitaal-erfgoed/dataset-register#2085), each in its own commit.

### 1. Schema-fingerprint rebuild trigger

The docs described blue/green rebuild and the full-vs-incremental update modes but never said **what triggers a full rebuild**. The answer is a **fingerprint** over index-affecting config (field registry, fold-map version, projection/CONSTRUCT logic) stored on the live collection; query-time params (weights, synonyms, typo tolerance, sort) are *excluded* and synced live. Mismatch → blue/green rebuild; match → incremental path. Deploy-driven and automatic – no cron, no manual flag. Distinct from the source-change trigger.

- `docs/stack/patterns.md` – new "Rebuild trigger: schema fingerprint" subsection under Blue/green Rebuild.
- `docs/stack/pipeline.md` – clarifies that the config-change trigger is orthogonal to the source-change Trigger axis.
- `docs/stack/layers/platform.md` – Mode 1 rebuilds fire on a fingerprint change, not a schedule.

### 2. Engine-dependent normalization

The Multilingual envelope section assumed the engine folds/stems natively (true for Lucene). Typesense cannot fold non-decomposing letters (ø/æ/ß) and stem Dutch at once, so a shared fold utility (proposed `@lde/text-normalization`) must run **identically at index and query time** – divergence is a silent miss. Framed as a Ports & Adapters consequence: an adapter can push an obligation back onto the projection, and here it reaches past the pipeline onto the query side.

- `docs/stack/layers/platform.md` – new "Normalization is engine-dependent" subsection.
- `docs/stack/patterns.md` – matching tradeoff in Ports & Adapters.

## Validation

`npm run build` passes. The only broken-anchor warnings (`#data-layer`/`#publication`/`#presentation-layer` on the layers index page) are pre-existing and untouched; all new cross-reference anchors resolve.
