### PR TITLE
docs(dataset-register): document distribution validity and usability

### DIFF
--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -208,6 +208,7 @@ Each probed URL appears as a `nde-probe:DistributionHealthRecord` whose IRI **is
 | `nde-probe:lastSuccessAt`      | `xsd:dateTime` — UTC timestamp of the most recent successful probe, if any.                                                                                                                     | 0..1        |
 | `nde-probe:firstFailureAt`     | `xsd:dateTime` — UTC timestamp at which the current failure streak began. Cleared on the next success.                                                                                          | 0..1        |
 | `nde-probe:consecutiveFailures`| `xsd:integer` — length of the current failure streak. Reset to `0` on the next success.                                                                                                         | 1..1        |
+| `nde-probe:sourceFingerprint`  | `xsd:string` — opaque source-change fingerprint observed on the last probe (the most recent of the declared `dct:modified` and the HTTP `Last-Modified`, combined with the byte size). The shared key the [validity](#distribution-validity) staleness gate compares against. Absent when none could be derived (e.g. a SPARQL endpoint). | 0..1 |
 
 ### Probe outcomes
 
@@ -222,13 +223,59 @@ When a probe fails, `nde-probe:lastOutcome` is one of:
 | `nde-probe:RateLimited`              | HTTP `429`.                                                                                   |
 | `nde-probe:ContentTypeMismatch`      | Response was reachable but served the wrong content type. For a data dump, its `Content-Type` did not match the declared `dcat:mediaType` / `dct:format` / `schema:encodingFormat`. For a SPARQL endpoint, the response was not a SPARQL results media type – most often an HTML page, meaning the access URL points to a SPARQL query web UI rather than the SPARQL protocol endpoint itself. The fix is to put the SPARQL protocol endpoint in `dcat:accessURL` (`schema:contentUrl`) and declare the query UI on `foaf:page` (`schema:documentation`) instead. |
 | `nde-probe:ContentTypeMissing`       | Response had no `Content-Type` header at all.                                                 |
-| `nde-probe:EmptyBody`                | Response body was empty for a distribution that should have returned data.                    |
 | `nde-probe:SparqlProbeFailed`        | The distribution declares a SPARQL endpoint (`dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/>`) but the probe `ASK` query did not return a valid SPARQL result. |
-| `nde-probe:RdfParseFailed`           | The body was returned but could not be parsed as RDF.                                         |
+
+:::note
+
+An empty body and an unparseable body used to be reachability outcomes (`nde-probe:EmptyBody`, `nde-probe:RdfParseFailed`). They no longer are: a fetched body that is empty or does not parse is reachable, and the defect is recorded on the [validity rail](#distribution-validity) instead.
+
+:::
 
 ### Effect on validation results
 
 Probe failures also surface in the SHACL validation report as `sh:ValidationResult` nodes. See [Validation: how probe failures appear in the report](validation.md#how-probe-failures-appear-in-the-report) for the constraint components, the extra properties they carry, and how strict each caller (registration, validation, crawler) is.
+
+## Distribution validity
+
+Where [distribution health](#distribution-health) records **reachability**, distribution validity records whether a distribution’s fetched content actually **parses as RDF**. The crawler shallow-validates small RDF dumps (≤ 10 KB Turtle / N-Triples / N-Quads) and records the verdict — for every distribution it attempts, valid or not — as a [DQV](https://www.w3.org/TR/vocab-dqv/) quality measurement in a dedicated named graph:
+
+```text
+https://datasetregister.netwerkdigitaalerfgoed.nl/sparql/distribution-validity
+```
+
+Like distribution health, this is **enrichment data produced by the register**, kept in its own graph and replaced on every crawl. The same measurement shape is also produced by the [Dataset Knowledge Graph](../dataset-knowledge-graph/index.md), which deep-validates the full distribution; a consumer tells the two apart by which endpoint served the measurement, not by the RDF.
+
+Vocabulary prefixes: `dqv: <http://www.w3.org/ns/dqv#>`, `prov: <http://www.w3.org/ns/prov#>`, `metric: <https://def.nde.nl/metric#>`, `failure: <https://def.nde.nl/failure#>`, `dvf: <https://def.nde.nl/distribution-validity-failure#>`, `probe: <https://def.nde.nl/probe#>`.
+
+### `dqv:QualityMeasurement`
+
+Each validated distribution carries a `dqv:QualityMeasurement` of the boolean metric `metric:distribution-rdf-valid`, computed on the distribution’s access URL — the file itself, because validity is a property of the bytes, not of any dataset’s use of them.
+
+| Property                  | Data type / notes                                                                                                                                  | Cardinality |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `dqv:isMeasurementOf`     | `metric:distribution-rdf-valid`.                                                                                                                    | 1..1        |
+| `dqv:computedOn`          | The distribution’s access URL.                                                                                                                      | 1..1        |
+| `dqv:value`               | `xsd:boolean` — `true` when the content parsed as RDF, `false` otherwise.                                                                           | 1..1        |
+| `prov:generatedAtTime`    | `xsd:dateTime` — when the verdict was produced.                                                                                                     | 1..1        |
+| `prov:wasGeneratedBy`     | A `prov:Activity` carrying `prov:wasAssociatedWith` the producer (the register crawler).                                                            | 1..1        |
+| `probe:sourceFingerprint` | `xsd:string` — the source fingerprint the verdict was judged against; matched against the [health record](#nde-probedistributionhealthrecord)’s fingerprint by the staleness gate. Absent when none could be derived. | 0..1 |
+
+When the verdict is `false`, the activity additionally `prov:qualifiedUsage` a `prov:Usage` recording why:
+
+| Property          | Data type / notes                                                                                                                      | Cardinality |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `failure:reason`  | A SKOS concept from the `distribution-validity-failure` scheme: `dvf:parse-error` (the content could not be parsed) or `dvf:empty` (it parsed but yielded no triples, or the body was empty). | 1..1 |
+| `failure:message` | `xsd:string` — best-effort parser message, where the parser provides one. Advisory only.                                               | 0..1        |
+
+### Usability
+
+`reachability` and `validity` are combined, on read, into a single **usability** verdict — `usable`, `unusable`, or `unknown` — that the [browser](https://datasetregister.netwerkdigitaalerfgoed.nl/) surfaces as a per-distribution badge. The rule is:
+
+- **Reachability dominates:** an unreachable distribution is `unusable` (cause: unreachable), regardless of any validity verdict.
+- A reachable distribution with a `false` validity verdict is `unusable` (cause: invalid), with the reason and parser message.
+- A reachable distribution with a `true` validity verdict is `usable`.
+- **Staleness gate:** a validity verdict applies only while its `probe:sourceFingerprint` still equals the currently-observed one; otherwise it decays to `unknown`, so a since-fixed distribution stops showing as broken.
+- **Depth:** a deep (Knowledge Graph) verdict wins over a shallow (register) one; a shallow verdict still counts but is flagged as not yet deeply confirmed.
 
 ## Allow list
 

--- a/docs/services/dataset-register/validation.md
+++ b/docs/services/dataset-register/validation.md
@@ -63,9 +63,20 @@ it flips to `false` on warnings and infos too, which is stricter than what the r
 For the exact JSON-LD and Turtle shapes of the report, see the `Valid` and `Invalid` response
 schemas in the [OpenAPI specification](https://datasetregister.netwerkdigitaalerfgoed.nl/api/).
 
-## Distribution-health probes
+## Distribution health
 
-During validation the Register also probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to check that it is reachable and serves the declared media type. Even when the description passes SHACL, a broken or mistyped distribution URL is reported as a `sh:Violation` and rejected with HTTP `400` — so fix the URL before (re)submitting.
+The Register models a distribution’s health as a derived **usability** verdict over two separately-produced signals:
+
+- **reachability** – can the distribution be fetched? (HTTP/SPARQL level)
+- **validity** – does the fetched content actually parse as RDF?
+
+During validation the Register probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to produce both signals: it checks that the URL is reachable and serves the declared media type (reachability), and, for small RDF dumps (≤ 10 KB Turtle / N-Triples / N-Quads), that the body parses as RDF (validity). Even when the description passes SHACL, a broken or mistyped distribution URL, or a body that does not parse as RDF, is reported as a `sh:Violation` and rejected with HTTP `400` — so fix it before (re)submitting.
+
+:::note
+
+Reachability and validity are distinct. A body that is fetched but does not parse (or comes back empty) is still **reachable**; its defect is a **validity** failure, not a reachability one. The two are recorded on separate rails (see [Distribution health](data-model.md#distribution-health) and [Distribution validity](data-model.md#distribution-validity) in the data model) and combined into a single usability verdict on read.
+
+:::
 
 The REST API and the crawler differ in how strict they are about probe failures:
 
@@ -81,17 +92,20 @@ The REST API is strict regardless of the severity the shapes declare, so it will
 
 The crawler does not flag every probe failure immediately. Whether it waits out a grace window depends on whether the failure could plausibly resolve itself:
 
-- **Transient reachability failures** – `nde-probe:NetworkError`, `nde-probe:NotFound`, `nde-probe:ServerError`, `nde-probe:AuthRequired`, `nde-probe:RateLimited`, `nde-probe:SparqlProbeFailed` – are emitted only once the failure streak is persistent (`nde-probe:firstFailureAt` older than the threshold, default 7 days). A brief outage that self-heals before the threshold is suppressed, so a network blip neither warns the publisher nor flips the browser availability badge.
-- **Deterministic content defects** – `nde-probe:EmptyBody`, `nde-probe:RdfParseFailed`, `nde-probe:ContentTypeMismatch`, `nde-probe:ContentTypeMissing` – are surfaced within one probe cycle, with no grace window. An empty or unparseable body, or a `Content-Type` that does not match the declared media type, is the same defect on the next crawl as it is today, so waiting cannot change the verdict.
+- **Transient reachability failures** – `nde-probe:NetworkError`, `nde-probe:NotFound`, `nde-probe:ServerError`, `nde-probe:AuthRequired`, `nde-probe:RateLimited`, `nde-probe:SparqlProbeFailed` – are emitted only once the failure streak is persistent (`nde-probe:firstFailureAt` older than the threshold, default 7 days). A brief outage that self-heals before the threshold is suppressed, so a network blip neither warns the publisher nor flips the browser usability badge.
+- **Deterministic content defects** – `nde-probe:ContentTypeMismatch`, `nde-probe:ContentTypeMissing` – are surfaced within one probe cycle, with no grace window. A `Content-Type` that does not match the declared media type, or none at all, is the same defect on the next crawl as it is today, so waiting cannot change the verdict.
 
-The browser availability badge uses the same classification, so the badge and the registration warning tier stay consistent.
+Empty and unparseable bodies are **not** reachability outcomes: a fetched body that is empty or does not parse is reachable, and its defect is recorded on the [validity rail](data-model.md#distribution-validity) instead. A validity verdict refreshes when the distribution’s source fingerprint changes, rather than riding out a grace window.
+
+The browser usability badge uses the same classification, so the badge and the registration warning tier stay consistent.
 
 ### How probe failures appear in the report
 
-Probe failures surface in the validation report as additional `sh:ValidationResult` nodes, with one of two probe-specific constraint components on `sh:sourceConstraintComponent`:
+Probe failures surface in the validation report as additional `sh:ValidationResult` nodes, with one of three probe-specific constraint components on `sh:sourceConstraintComponent`:
 
 - `nde-probe:DistributionReachableConstraintComponent` — the URL itself could not be retrieved.
 - `nde-probe:DistributionFormatMatchConstraintComponent` — the URL was retrieved but the response did not match the declared media type / format.
+- `nde-probe:DistributionValidConstraintComponent` — the body was retrieved but did not parse as RDF (a validity failure). Emitted only on the registration path (`POST /datasets`, `POST`/`PUT /datasets/validate`); the crawler records validity as a quality measurement instead (see [Distribution validity](data-model.md#distribution-validity)). The `sh:resultMessage` names the reason and, where the parser provides one, the parser message.
 
 Probe-emitted results carry these extra properties beyond the standard SHACL ones:
 
@@ -101,4 +115,4 @@ Probe-emitted results carry these extra properties beyond the standard SHACL one
 | `nde-probe:firstFailureAt`       | `xsd:dateTime` — copied from the health record, so consumers see how long the URL has been failing without joining the health graph. Present only on crawler-emitted results. |
 | `nde-probe:consecutiveFailures`  | `xsd:integer` — length of the current failure streak. Present only on crawler-emitted results. |
 
-Every probe the crawler runs — successful or not — is also recorded as queryable enrichment data. See [Distribution health](data-model.md#distribution-health) in the data model for that named graph, the [`nde-probe:DistributionHealthRecord`](data-model.md#nde-probedistributionhealthrecord) structure, and the [outcome vocabulary](data-model.md#probe-outcomes).
+Every probe the crawler runs — successful or not — is also recorded as queryable enrichment data: its reachability outcome and observed source fingerprint in the [Distribution health](data-model.md#distribution-health) graph (the [`nde-probe:DistributionHealthRecord`](data-model.md#nde-probedistributionhealthrecord) structure and the [outcome vocabulary](data-model.md#probe-outcomes)), and its RDF-validity verdict in the [Distribution validity](data-model.md#distribution-validity) graph as a DQV quality measurement.


### PR DESCRIPTION
Documents the distribution-validity / usability model in the Dataset Register chapter, mirroring the code change in netwerk-digitaal-erfgoed/dataset-register#2120.

## What changed

- **Validation chapter** — recast the “distribution-health probes” section around the two rails (reachability + validity) and a derived usability verdict. Corrects the grace-window list (empty/unparseable bodies are no longer reachability outcomes — they moved to the validity rail) and adds the `nde-probe:DistributionValidConstraintComponent` used when registration rejects invalid RDF.
- **Data-model chapter** — added `nde-probe:sourceFingerprint` to the health record; removed the retired `nde-probe:EmptyBody` / `nde-probe:RdfParseFailed` outcomes (with a migration note); and added a new **Distribution validity** section documenting the `distribution-validity` graph, the `metric:distribution-rdf-valid` DQV quality measurement (`failure:reason`/`failure:message`, `probe:sourceFingerprint`), and the usability rollup rule (reachability dominates, staleness gate, depth preference).

Docusaurus build passes; the only broken anchors it reports are in `docs/stack/layers` from unrelated in-flight work, not these pages.
