### PR TITLE
docs: point the JSON-LD context to its canonical schema-profile URL

### DIFF
--- a/blog/2026-03-09-schema.org.md
+++ b/blog/2026-03-09-schema.org.md
@@ -164,17 +164,17 @@ This follows the [robustness principle](https://en.wikipedia.org/wiki/Robustness
 
 For the JSON-LD case, rather than requiring every data publisher to adopt a custom context, **the responsibility sits with consumers**. Publishers keep using the standard `"@context": "https://schema.org"` – no extra dependencies. Consumers apply a shared context when processing incoming JSON-LD data, rewriting `http://` terms to `https://` at ingestion time.
 
-NDE provides [this context](https://docs.nde.nl/schema.org/context.jsonld) using the [`@import`](#what-about-a-custom-context) mechanism described above. Consumers replace the context of incoming documents before expansion:
+NDE provides [this context](https://docs.nde.nl/schema-profile/context.jsonld) using the [`@import`](#what-about-a-custom-context) mechanism described above. Consumers replace the context of incoming documents before expansion:
 
 ```javascript
 // Node (jsonld.js)
-document['@context'] = 'https://docs.nde.nl/schema.org/context.jsonld';
+document['@context'] = 'https://docs.nde.nl/schema-profile/context.jsonld';
 const expanded = await jsonld.expand(document);
 ```
 
 ```python
 # Python (pyld)
-document["@context"] = "https://docs.nde.nl/schema.org/context.jsonld"
+document["@context"] = "https://docs.nde.nl/schema-profile/context.jsonld"
 expanded = jsonld.expand(document)
 ```
 

--- a/i18n/nl/docusaurus-plugin-content-blog/2026-03-09-schema.org.md
+++ b/i18n/nl/docusaurus-plugin-content-blog/2026-03-09-schema.org.md
@@ -163,17 +163,17 @@ Dit volgt het [robuustheidsprincipe](https://en.wikipedia.org/wiki/Robustness_pr
 
 Bij JSON-LD ligt de verantwoordelijkheid niet bij de bronhouder maar bij de **afnemer**. Bronhouders blijven gewoon `"@context": "https://schema.org"` gebruiken – geen extra afhankelijkheden. Afnemers passen een gedeelde context toe bij het verwerken van binnenkomende JSON-LD-data, waarmee `http://`-termen worden herschreven naar `https://` bij inname.
 
-NDE biedt [deze context](https://docs.nde.nl/schema.org/context.jsonld) aan via het [`@import`](#kan-een-eigen-context-helpen)-mechanisme dat hierboven is beschreven. Afnemers vervangen de context van binnenkomende documenten vóór expansie:
+NDE biedt [deze context](https://docs.nde.nl/schema-profile/context.jsonld) aan via het [`@import`](#kan-een-eigen-context-helpen)-mechanisme dat hierboven is beschreven. Afnemers vervangen de context van binnenkomende documenten vóór expansie:
 
 ```javascript
 // Node (jsonld.js)
-document['@context'] = 'https://docs.nde.nl/schema.org/context.jsonld';
+document['@context'] = 'https://docs.nde.nl/schema-profile/context.jsonld';
 const expanded = await jsonld.expand(document);
 ```
 
 ```python
 # Python (pyld)
-document["@context"] = "https://docs.nde.nl/schema.org/context.jsonld"
+document["@context"] = "https://docs.nde.nl/schema-profile/context.jsonld"
 expanded = jsonld.expand(document)
 ```
 


### PR DESCRIPTION
The schema.org blog post (English and Dutch) linked the shared NDE JSON-LD context at the old location `https://docs.nde.nl/schema.org/context.jsonld`.

That URL still resolves, but now serves an **older, minimal** context – only the `http`→`https` override, **without** the `@container: @set` (always-array) and `@container: @language` (language-map) declarations. The canonical, full context is hosted with the profile at `https://docs.nde.nl/schema-profile/context.jsonld`.

So readers following the blog were getting the less-capable context. This updates all six references (prose link + JS + Python, in both EN and NL) to the canonical URL.

Note: the stale copy at `static/schema.org/context.jsonld` is left in place for now (the old URL keeps working); retiring it / redirecting to the canonical URL is a separate follow-up.
