### PR TITLE
docs: remove the superseded schema.org JSON-LD context

### DIFF
--- a/static/schema.org/context.jsonld
+++ b/static/schema.org/context.jsonld
@@ -1,8 +1,0 @@
-{
-  "@context": {
-    "@version": 1.1,
-    "@import": "https://schema.org/docs/jsonldcontext.jsonld",
-    "@vocab": "https://schema.org/",
-    "schema": "https://schema.org/"
-  }
-}


### PR DESCRIPTION
Follow-up to #121 (which pointed the blog at the canonical context URL).

Removes the superseded copy of the shared NDE JSON-LD context at `static/schema.org/context.jsonld`. The canonical, full context (with `@set` arrays and `@language` maps) is hosted with the profile at `https://docs.nde.nl/schema-profile/context.jsonld`, and the blog now references it.

**Breaking for external consumers:** the old URL `https://docs.nde.nl/schema.org/context.jsonld` will start returning 404. A real HTTP redirect isn't possible here (docs.nde.nl is GitHub Pages, and a `.jsonld` can't be redirected via Docusaurus/Jekyll client-side redirects), so removal is the chosen path. No internal references remain (the blog EN + NL were updated in #121).
