### PR TITLE
docs(dkg): note SCHEMA-AP-NDE conformance counts only sh:Violation

### DIFF
--- a/docs/services/dataset-knowledge-graph/index.md
+++ b/docs/services/dataset-knowledge-graph/index.md
@@ -444,6 +444,8 @@ SELECT * WHERE {
 
 The `?n > 0` filter excludes datasets that use a different data model and to which the profile doesn't apply at all (where SHACL returns *vacuously true*). To find datasets that tried the profile and failed, swap `dqv:value true` for `dqv:value false`.
 
+Conformance counts only `sh:Violation` results: SCHEMA-AP-NDE’s `sh:Warning` constraints are SHOULD-level, so a sample that trips only warnings still reports `schema-ap-nde-sample-conformance = true`. The warnings are not lost – they stay in the full per-resource SHACL report written alongside the summary – they just don’t flip the conformance boolean.
+
 ## Access
 
 - **Datastory** for visual aggregate insights across all datasets: [datastories.demo.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph](https://datastories.demo.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph/index.html).


### PR DESCRIPTION
Documents the behaviour change in [dataset-knowledge-graph#417](https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph/pull/417) (fixes dataset-knowledge-graph#411).

The DKG now fails SCHEMA-AP-NDE conformance only on `sh:Violation`, so `sh:Warning` (SHOULD-level) results no longer flip the published `schema-ap-nde-sample-conformance` measurement. This note, in the “Datasets passing SCHEMA-AP-NDE” section, makes that explicit and points out the warnings are still in the full per-resource SHACL report.
