### PR TITLE
docs(use): rewrite Discover and add Access and Transform chapters

### DIFF
--- a/docs/use/access.md
+++ b/docs/use/access.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 2
+description: Download a data dump or query a SPARQL endpoint to retrieve a dataset’s content.
+---
+
+# Access
+
+You have [discovered a dataset](discover.md) and read its [distributions](../glossary.md#distribution); now you want its content. 
+How you get it depends on the distribution you picked:
+
+* a **data dump** is a file you download and process locally;
+* a **SPARQL endpoint** you query at the source, without keeping a copy.
+
+A dataset may offer either or both; choose whichever fits how you work.
+Either way you fetch the content from the publisher at the source, not from the
+[Dataset Register](../services/dataset-register/index.md), which holds descriptions, not data.
+
+## Download a data dump
+
+### Find the dump’s URL
+
+Read the dump’s access URL (`dcat:accessURL`) off the distribution, along with its media type
+(`dcat:mediaType`), which tells you the [RDF](../glossary.md#rdf) serialisation to expect. If the dump
+is compressed, you will find the compression in `dcat:compressFormat`. For the full set of properties,
+see the [distribution data model](../services/dataset-register/data-model.md#dcatdistribution).
+
+### Download it
+
+A dump is a plain HTTP resource, so reach for any HTTP client. Dumps are often gzip-compressed, so you
+may need to unpack what you download:
+
+```shell
+curl -LO https://example.org/collection.nt.gz
+gunzip collection.nt.gz
+```
+
+`-L` follows redirects, which publishers commonly use for persistent download URLs; `-O` keeps the
+server-provided filename.
+
+### Match your parser to the serialisation
+
+The media type on the distribution tells you how to read the dump. You will most often meet these RDF
+serialisations:
+
+| Serialisation | Typical extension | Media type |
+| --- | --- | --- |
+| N-Triples | `.nt` | `application/n-triples` |
+| N-Quads | `.nq` | `application/n-quads` |
+| Turtle | `.ttl` | `text/turtle` |
+| RDF/XML | `.rdf`, `.xml` | `application/rdf+xml` |
+| JSON-LD | `.jsonld` | `application/ld+json` |
+
+Most RDF tooling reads all of these; point your parser at the media type the distribution declared.
+
+### Work with the dump
+
+Once the dump is on disk, you can:
+
+* **query it** by loading it into a local triplestore (QLever, Oxigraph, Jena Fuseki, …) and running
+  SPARQL against your own copy, so you no longer depend on the source being up;
+* [transform](transform.md) it into the model your application needs.
+
+## Query a SPARQL endpoint
+
+If you would rather not keep a copy, query the source directly. A SPARQL-endpoint distribution declares
+its protocol with `dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/>`, 
+and its `dcat:accessURL` is the endpoint you send queries to. 
+You always see the current data, and you store nothing yourself.
+
+Send a query with any SPARQL client. From the command line with cURL:
+
+```shell
+curl -X POST https://www.goudatijdmachine.nl/sparql/repositories/gtm \
+  --data 'query=SELECT * WHERE { ?s ?p ?o } LIMIT 10'
+```
+
+Or with a dedicated client such as
+[Comunica](https://comunica.dev/docs/query/getting_started/query_cli/):
+
+```shell
+npm install -g @comunica/query-sparql
+comunica-sparql sparql@https://www.goudatijdmachine.nl/sparql/repositories/gtm \
+  "SELECT * WHERE { ?s ?p ?o } LIMIT 10"
+```
+
+## Keep your copy current
+
+Whether you downloaded a dump or cached a query result, what you hold is a snapshot, so refresh it
+when the source moves on. Rather than re-fetching on a hunch, compare the distribution’s
+`dct:modified` – the date the data itself last changed, distinct from when the dataset description was
+updated – against your last copy, and re-fetch only when it has advanced. See
+[Discover → Re-fetch only what changed](discover.md#re-fetch-only-what-changed).

--- a/docs/use/discover.md
+++ b/docs/use/discover.md
@@ -1,12 +1,91 @@
 ---
 sidebar_position: 1
-description: Use the Dataset Register to find datasets.
+description: Find heritage datasets in the Dataset Register and follow them to the data at the source.
 ---
 
 # Discover
 
-You can use the [Dataset Register website](https://datasetregister.netwerkdigitaalerfgoed.nl/en/datasets)
-to find heritage datasets. 
+The [Dataset Register](../services/dataset-register/index.md) is the place to find heritage datasets
+and discover where their data lives. It holds a
+[description](../glossary.md#dataset-description) of each dataset (including its name, publisher, 
+license and where to get the data).
+Descriptions are published by [data providers](../glossary.md#data-provider);
+the Register keeps a cached copy of it, refreshed from the source daily.
+The data itself always stays at the source.
 
-The [Dataset Knowledge Graph](../services/dataset-knowledge-graph/index.md)
-provides additional statistics about each dataset.
+Retrieving a dataset therefore takes two steps:
+
+1. **Find its description in the Register**, which tells you the dataset exists and where its data is.
+2. **Fetch the data from the source**, by following the description’s [distributions](../glossary.md#distribution).
+
+## What the Register adds
+
+Caching a catalog of these descriptions lets the Register build on them, giving you:
+
+- **A uniform, validated model.**
+  On ingest, the Register [validates](../services/dataset-register/validation.md) each
+  publisher-provided description and converts it to a uniform
+  [data model](../services/dataset-register/data-model.md) that is easier to query.
+- **Reachable distributions.**
+  A valid description can still point to a distribution that is offline or has moved, so the Register
+  [probes each distribution](../services/dataset-register/data-model.md#distribution-health) to confirm
+  it responds, giving you reliable access to the data.
+- **A Linked Data summary.** 
+  The [Dataset Knowledge Graph](../services/dataset-knowledge-graph/index.md) enriches each entry with the
+  dataset’s empirical shape (including triple counts, classes, properties, vocabularies and terminology sources used)
+  so you can assess a dataset before retrieving it and see which classes and properties to target in your queries.
+- **Full-catalog search.** Search every description in one place with full-text search and facets,
+  instead of hunting source by source, so you find every dataset matching your criteria across the
+  network. An RSS feed per query notifies you when new matching datasets are registered.
+
+## Find a dataset
+
+How you search depends on whether a person or a program is doing the looking.
+
+**If you are browsing**, use the
+[Dataset Register website](https://datasetregister.netwerkdigitaalerfgoed.nl/en/datasets), a
+human-readable search interface with facets for publisher, terminology source, size and format.
+
+**If you are automating**, query the Register’s
+[SPARQL endpoint](../services/dataset-register/sparql.md). It exposes every registered description in
+[DCAT](../services/dataset-register/data-model.md), so you can narrow the list at query time – by
+keyword, publisher, subject, `dcterms:conformsTo`, or validation status – instead of fetching
+everything and filtering afterwards. Usually you want valid datasets only, so that you skip any whose
+latest fetch failed to produce a valid description; the
+[registration-status](../services/dataset-register/sparql.md#registration-status) section shows that
+query.
+
+The Register is a [DCAT-AP-NL](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/) registry, so you can read it with any DCAT-AP client rather than writing SPARQL by hand. 
+For TypeScript/JavaScript, the [`@lde/dataset-registry-client`](https://github.com/ldelements/lde/tree/main/packages/dataset-registry-client) library does this for you.
+
+## Follow a dataset to its data
+
+When you have found a dataset you want, read its
+[distributions](../glossary.md#distribution) off the description: these are the concrete access points
+for the data. 
+For linked data, each one is either a **data dump** you download or a **SPARQL endpoint** you query at the source.
+Pick a distribution, then continue to [Access](access.md) to fetch the content.
+
+## Re-fetch only what changed
+
+If you come back for the same datasets repeatedly (say you ingest them on a schedule) you do not
+want to re-download everything every time. Use the Register to detect what changed. Because it re-crawls
+every source daily, its copy of each distribution’s `dct:modified` tells you, across every dataset in a
+single query, whether the data has changed since you last ingested it. Compare against the
+distribution’s modification date, not the dataset description’s: the description’s date changes when the
+metadata is edited, while the distribution’s date tracks the data itself. If it has advanced, go back to
+the source and re-fetch; if not, skip it. The trigger comes from the Register, but the data still comes
+from the source.
+
+See also the Stack’s
+[Discovery via DCAT-AP Registry](../stack/patterns.md#discovery-via-dcat-ap-registry) and
+[Change-driven Rebuild](../stack/patterns.md#change-driven-rebuild) patterns.
+
+## Discovering in a pipeline
+
+If you are building a [Service Platform](../glossary.md#service-platform) that ingests datasets
+automatically, make the Register the first stage of your pipeline. Rather than maintaining a
+handwritten list of sources to pull from, query the Register at the start of each run to get the
+current set of datasets to process. New datasets are then picked up as soon as they are registered,
+without you touching any code. The Stack describes this as the
+[Discovery via DCAT-AP Registry](../stack/patterns.md#discovery-via-dcat-ap-registry) pattern.

--- a/docs/use/download.md
+++ b/docs/use/download.md
@@ -1,3 +1,0 @@
-# Download datasets
-
-Download dataset distributions to use locally.

--- a/docs/use/query.md
+++ b/docs/use/query.md
@@ -1,3 +1,0 @@
-# Query
-
-Query datasets using SPARQL

--- a/docs/use/transform.md
+++ b/docs/use/transform.md
@@ -1,5 +1,32 @@
+---
+sidebar_position: 3
+description: Reshape a dataset into the model your application needs with SPARQL CONSTRUCT.
+---
+
 # Transform
 
-Transform data to make it usable in [Service Platforms](../glossary.md#service-platform).
+The data you [access](access.md) rarely matches the exact model your application or
+[Service Platform](../glossary.md#service-platform) needs, so you reshape it. 
+NDE recommends doing this with SPARQL, keeping transformations declarative and portable rather than locked inside bespoke scripts.
 
-* LD Workbench. Transform data using LD Workbench. 
+## Transform RDF with SPARQL CONSTRUCT
+
+For RDF-to-RDF transformations, NDE recommends **SPARQL `CONSTRUCT`**: you write a query that reads the
+source shape and constructs the target shape, often as several small steps chained together. Because
+the transformation is an ordinary SPARQL query rather than custom code, it is portable across tools and
+inspectable – the same approach the Stack’s [pipelines](../stack/pipeline.md) use to project source
+data into search indexes, knowledge graphs and [EDM](https://pro.europeana.eu/page/edm-documentation).
+
+When a source has several independently multi-valued properties, split the mapping into small
+`CONSTRUCT` queries joined by `UNION` rather than one query full of `OPTIONAL`s, so multi-valued
+properties do not multiply into cross-product duplicates.
+
+## Transform non-RDF with SPARQL Anything
+
+If your source is not RDF (e.g. a CSV or TSV, JSON, XML or Excel file) you can still use the `CONSTRUCT`
+you already know, with [SPARQL Anything](https://sparql-anything.cc). It presents any such source
+through a uniform RDF facade, so you query it with an ordinary `CONSTRUCT` and a `SERVICE` block; it
+does not extend the SPARQL grammar, so your existing skills transfer directly.
+
+For a worked example, see [Turning GeoNames into linked data](/blog/2026/06/25/geonames-linked-data),
+which converts the 13-million-row GeoNames TSV dump to RDF using nothing but `CONSTRUCT`.


### PR DESCRIPTION
## What

Rewrites and completes the **Use datasets** chapter, framing every page from the reader’s perspective and filling in the remaining stubs.

### Discover
- Leads with the Dataset Register as *the place to find datasets*, and clarifies that descriptions – like the data – are provided by publishers; the Register only caches them.
- New **What the Register adds** section: a uniform, validated model; reachable distributions (health probes); a Linked Data summary from the Dataset Knowledge Graph; full-catalog search.
- Notes the Register is a DCAT-AP-NL registry, readable with any DCAT-AP client (`@lde/dataset-registry-client`).
- Rewrites the pipeline section to explain the Register as a dynamic source list.

### Access (new)
- Merges the former **Download** and **Query** stubs into one chapter covering the two distribution types: data dumps you download, and SPARQL endpoints you query at the source.

### Transform
- Recommends **SPARQL `CONSTRUCT`** for RDF-to-RDF transformations (consistent with the Stack’s pipelines) and **SPARQL Anything** for non-RDF sources, linking the GeoNames post as a worked example.

### Correctness fix
- The re-fetch signal now points at the **distribution’s** `dct:modified` (the data’s modification date) rather than the dataset description’s, per the [Requirements for Datasets](https://docs.nde.nl/requirements-datasets/#distribution-date).

## Notes
- `download.md` and `query.md` are removed; the inbound link in `landscape.md` was updated to `access.md` (that file is part of separate in-progress work and is not included here).
- Verified links statically; no Docusaurus build run.
