### PR TITLE
docs(stack): add SPARQL-native Transformation pattern

### DIFF
--- a/docs/stack/patterns.md
+++ b/docs/stack/patterns.md
@@ -52,7 +52,7 @@ flowchart TB
     %% Meta-patterns
     CP -- requires --> PA
     CP -- transform stage realised by --> SNT["SPARQL-native<br/>Transformation"]
-    SNT -- escapes to --> PA
+    SNT -- supplemented by --> PA
 
     %% Network-wide
     SAP -- pairs --> SAC
@@ -85,7 +85,7 @@ Relationship vocabulary used in the diagram:
 - **composes with**: optional combination – either pattern works on its own, both together unlock a configuration.
 - **requires**: hard dependency – the upstream pattern cannot deliver its property without the downstream.
 - **realised by**: the downstream pattern is the concrete technique that implements a specific stage of the upstream one (here, the Transform stage of Configurable Pipeline).
-- **escapes to**: the technique falls back to the downstream pattern for the cases it cannot express itself.
+- **supplemented by**: the technique relies on the downstream pattern for the cases it cannot express itself.
 - **alternatives**: choose one or the other for the same axis (Blue/green vs In-place at the Deploy axis).
 - **publishes back via** / **registered in**: closes a loop – an output of one pattern becomes a published input the other discovers.
 
@@ -499,7 +499,7 @@ Prefer **several small `CONSTRUCT`s chained** over one monolithic query. Each st
 - **CONSTRUCT to a published shape.** The target is usually a published AP, usually [SCHEMA-AP-NDE](#schema-ap-nde-first), or a downstream profile such as EDM. The same SHACL that defines the target shape both drives the mapping and validates its output.
 - **UNION, not OPTIONAL, for independently multi-valued properties.** One `CONSTRUCT` full of `OPTIONAL`s multiplies multi-valued properties into a cross-product of duplicate triples; giving each its own `UNION` branch (each binding only its own variable) avoids that. Keep related single-valued properties together in one `OPTIONAL`.
 - **Non-RDF sources enter through a SPARQL facade.** A CSV/TSV, JSON, XML or spreadsheet source is transformed with the same `CONSTRUCT` via [SPARQL Anything](https://sparql-anything.cc), which presents any such source as RDF (Facade-X) behind a `SERVICE` block without extending the SPARQL grammar. A non-RDF source therefore does not force a different transformation toolchain.
-- **Escape to an adapter where SPARQL cannot reach.** Logic SPARQL genuinely cannot express (bespoke normalisation, an external lookup) moves to a named [port/adapter](#adapters) boundary rather than sprawling as procedural glue inside the mapping.
+- **Supplement with an adapter where SPARQL cannot reach.** Logic SPARQL genuinely cannot express (bespoke normalisation, an external lookup) moves to a named [port/adapter](#adapters) boundary rather than sprawling as procedural glue inside the mapping.
 
 #### Why this matters
 

--- a/docs/stack/patterns.md
+++ b/docs/stack/patterns.md
@@ -51,6 +51,8 @@ flowchart TB
 
     %% Meta-patterns
     CP -- requires --> PA
+    CP -- transform stage realised by --> SNT["SPARQL-native<br/>Transformation"]
+    SNT -- escapes to --> PA
 
     %% Network-wide
     SAP -- pairs --> SAC
@@ -82,6 +84,8 @@ Relationship vocabulary used in the diagram:
 - **feeds**: one pattern's output becomes another's input.
 - **composes with**: optional combination – either pattern works on its own, both together unlock a configuration.
 - **requires**: hard dependency – the upstream pattern cannot deliver its property without the downstream.
+- **realised by**: the downstream pattern is the concrete technique that implements a specific stage of the upstream one (here, the Transform stage of Configurable Pipeline).
+- **escapes to**: the technique falls back to the downstream pattern for the cases it cannot express itself.
 - **alternatives**: choose one or the other for the same axis (Blue/green vs In-place at the Deploy axis).
 - **publishes back via** / **registered in**: closes a loop – an output of one pattern becomes a published input the other discovers.
 
@@ -478,7 +482,30 @@ The register today sits in the top-right cell: one `datasets` collection, two so
 Data Layer pipelines are **configured, not coded**. Pipeline structure is explicit in configuration artifacts (SHACL shapes for projection, SPARQL CONSTRUCT for extraction, JSON-LD Frames for output shaping) not buried inside bespoke scripts.
 Custom code lives only at [port/adapter](#adapters) boundaries (a writer, a filter compiler). The contrast is with implicit, coded pipelines whose stages, transformations, and assumptions are visible only to the people maintaining the code.
 
+The Transform stage’s own realisation – SPARQL `CONSTRUCT` for RDF and non-RDF sources alike – is the [SPARQL-native Transformation](#sparql-native-transformation) pattern below.
+
 See [Pipeline](pipeline.md) for the configuration axes, composition rules, and worked examples.
+
+## SPARQL-native Transformation
+
+*Applies to: [Data Layer](layers/platform.md#data-layer). Realises the Transform stage of [Configurable Pipeline](#configurable-pipeline); escapes to [Ports & Adapters](#adapters) for the mappings SPARQL cannot express. The consumer-facing how-to is [Use → Transform](../use/transform.md).*
+
+The Transform stage of a pipeline is written as **SPARQL `CONSTRUCT`**, not as imperative mapping code. Source RDF goes in, target-shape RDF comes out, and the query *is* the transformation specification – readable, diffable, and runnable by any SPARQL engine outside the pipeline. This is the Transform-stage realisation of [Configurable Pipeline](#configurable-pipeline)’s “configured, not coded” commitment: the mapping lives in a query artifact, not inside a bespoke script.
+
+Prefer **several small `CONSTRUCT`s chained** over one monolithic query. Each step targets one part of the output shape (e.g. `edm:ProvidedCHO`, then the aggregation, then constants), which keeps every step independently testable and lets [Last-known-good Caching](#last-known-good-per-source-caching) reuse the steps whose inputs did not change. The [EDM export pipeline](pipeline.md#example-edm-export-loda-pipeline) is built this way.
+
+#### Mechanics
+
+- **CONSTRUCT to a published shape.** The target is usually a published AP – most often the [SCHEMA-AP-NDE](#schema-ap-nde-first) pivot, or a downstream profile such as EDM. The same SHACL that defines the target shape both drives the mapping and validates its output.
+- **UNION, not OPTIONAL, for independently multi-valued properties.** One `CONSTRUCT` full of `OPTIONAL`s multiplies multi-valued properties into a cross-product of duplicate triples; giving each its own `UNION` branch (each binding only its own variable) avoids that. Keep related single-valued properties together in one `OPTIONAL`.
+- **Non-RDF sources enter through a SPARQL facade.** A CSV/TSV, JSON, XML or spreadsheet source is transformed with the same `CONSTRUCT` via [SPARQL Anything](https://sparql-anything.cc), which presents any such source as RDF (Facade-X) behind a `SERVICE` block without extending the SPARQL grammar. A non-RDF source therefore does not force a different transformation toolchain.
+- **Escape to an adapter where SPARQL cannot reach.** Logic SPARQL genuinely cannot express (bespoke normalisation, an external lookup) moves to a named [port/adapter](#adapters) boundary rather than sprawling as procedural glue inside the mapping.
+
+#### Why this matters
+
+- **The transformation is inspectable.** Every step’s input and output is RDF and its logic is a query, so the mapping can be read, diffed, and re-run standalone – unlike a transformation buried in code.
+- **One language across the stage.** RDF and non-RDF sources are transformed with the same `CONSTRUCT` skill set; there is no separate mapping DSL or per-format ETL tool to learn and maintain.
+- **The mapping is portable.** A `CONSTRUCT` runs on any SPARQL engine, so the Transform step is not married to a specific runtime – the same [Ports & Adapters](#adapters) substitutability the rest of the Stack relies on.
 
 ## Ports & Adapters {#adapters}
 

--- a/docs/stack/patterns.md
+++ b/docs/stack/patterns.md
@@ -482,30 +482,30 @@ The register today sits in the top-right cell: one `datasets` collection, two so
 Data Layer pipelines are **configured, not coded**. Pipeline structure is explicit in configuration artifacts (SHACL shapes for projection, SPARQL CONSTRUCT for extraction, JSON-LD Frames for output shaping) not buried inside bespoke scripts.
 Custom code lives only at [port/adapter](#adapters) boundaries (a writer, a filter compiler). The contrast is with implicit, coded pipelines whose stages, transformations, and assumptions are visible only to the people maintaining the code.
 
-The Transform stage’s own realisation – SPARQL `CONSTRUCT` for RDF and non-RDF sources alike – is the [SPARQL-native Transformation](#sparql-native-transformation) pattern below.
+The Transform stage’s own realisation is the [SPARQL-native Transformation](#sparql-native-transformation) pattern below.
 
 See [Pipeline](pipeline.md) for the configuration axes, composition rules, and worked examples.
 
 ## SPARQL-native Transformation
 
-*Applies to: [Data Layer](layers/platform.md#data-layer). Realises the Transform stage of [Configurable Pipeline](#configurable-pipeline); escapes to [Ports & Adapters](#adapters) for the mappings SPARQL cannot express. The consumer-facing how-to is [Use → Transform](../use/transform.md).*
+*Applies to: [Data Layer](layers/platform.md#data-layer). Realises the Transform stage of [Configurable Pipeline](#configurable-pipeline); supplemented by [Ports & Adapters](#adapters) for the mappings SPARQL cannot express. The consumer-facing how-to is [Use → Transform](../use/transform.md).*
 
-The Transform stage of a pipeline is written as **SPARQL `CONSTRUCT`**, not as imperative mapping code. Source RDF goes in, target-shape RDF comes out, and the query *is* the transformation specification – readable, diffable, and runnable by any SPARQL engine outside the pipeline. This is the Transform-stage realisation of [Configurable Pipeline](#configurable-pipeline)’s “configured, not coded” commitment: the mapping lives in a query artifact, not inside a bespoke script.
+The Transform stage of a pipeline is written as **SPARQL `CONSTRUCT`**, not as imperative mapping code. Source RDF goes in, target-shape RDF comes out, and the query *is* the transformation specification: readable, diffable, and runnable by any SPARQL engine outside the pipeline. This is the Transform-stage realisation of [Configurable Pipeline](#configurable-pipeline)’s “configured, not coded” commitment: the mapping lives in a query artifact, not inside a bespoke script.
 
 Prefer **several small `CONSTRUCT`s chained** over one monolithic query. Each step targets one part of the output shape (e.g. `edm:ProvidedCHO`, then the aggregation, then constants), which keeps every step independently testable and lets [Last-known-good Caching](#last-known-good-per-source-caching) reuse the steps whose inputs did not change. The [EDM export pipeline](pipeline.md#example-edm-export-loda-pipeline) is built this way.
 
 #### Mechanics
 
-- **CONSTRUCT to a published shape.** The target is usually a published AP – most often the [SCHEMA-AP-NDE](#schema-ap-nde-first) pivot, or a downstream profile such as EDM. The same SHACL that defines the target shape both drives the mapping and validates its output.
+- **CONSTRUCT to a published shape.** The target is usually a published AP, usually [SCHEMA-AP-NDE](#schema-ap-nde-first), or a downstream profile such as EDM. The same SHACL that defines the target shape both drives the mapping and validates its output.
 - **UNION, not OPTIONAL, for independently multi-valued properties.** One `CONSTRUCT` full of `OPTIONAL`s multiplies multi-valued properties into a cross-product of duplicate triples; giving each its own `UNION` branch (each binding only its own variable) avoids that. Keep related single-valued properties together in one `OPTIONAL`.
 - **Non-RDF sources enter through a SPARQL facade.** A CSV/TSV, JSON, XML or spreadsheet source is transformed with the same `CONSTRUCT` via [SPARQL Anything](https://sparql-anything.cc), which presents any such source as RDF (Facade-X) behind a `SERVICE` block without extending the SPARQL grammar. A non-RDF source therefore does not force a different transformation toolchain.
 - **Escape to an adapter where SPARQL cannot reach.** Logic SPARQL genuinely cannot express (bespoke normalisation, an external lookup) moves to a named [port/adapter](#adapters) boundary rather than sprawling as procedural glue inside the mapping.
 
 #### Why this matters
 
-- **The transformation is inspectable.** Every step’s input and output is RDF and its logic is a query, so the mapping can be read, diffed, and re-run standalone – unlike a transformation buried in code.
+- **The transformation is inspectable.** Every step’s input and output is RDF and its logic is a query, so the mapping can be read, diffed, and re-run standalone, unlike a transformation buried in code.
 - **One language across the stage.** RDF and non-RDF sources are transformed with the same `CONSTRUCT` skill set; there is no separate mapping DSL or per-format ETL tool to learn and maintain.
-- **The mapping is portable.** A `CONSTRUCT` runs on any SPARQL engine, so the Transform step is not married to a specific runtime – the same [Ports & Adapters](#adapters) substitutability the rest of the Stack relies on.
+- **The mapping is portable.** A `CONSTRUCT` runs on any SPARQL engine, so the Transform step is not married to a specific runtime: the same [Ports & Adapters](#adapters) substitutability the rest of the Stack relies on.
 
 ## Ports & Adapters {#adapters}
 

--- a/docs/use/access.md
+++ b/docs/use/access.md
@@ -58,7 +58,7 @@ Once the dump is on disk, you can:
 
 * **query it** by loading it into a local triplestore (QLever, Oxigraph, Jena Fuseki, …) and running
   SPARQL against your own copy, so you no longer depend on the source being up;
-* [transform](transform.md) it into the model your application needs.
+* [transform](transform.md) it into the model your application needs – the Stack does this with the [SPARQL-native Transformation](../stack/patterns.md#sparql-native-transformation) pattern.
 
 ## Query a SPARQL endpoint
 

--- a/docs/use/transform.md
+++ b/docs/use/transform.md
@@ -14,8 +14,9 @@ NDE recommends doing this with SPARQL, keeping transformations declarative and p
 For RDF-to-RDF transformations, NDE recommends **SPARQL `CONSTRUCT`**: you write a query that reads the
 source shape and constructs the target shape, often as several small steps chained together. Because
 the transformation is an ordinary SPARQL query rather than custom code, it is portable across tools and
-inspectable – the same approach the Stack’s [pipelines](../stack/pipeline.md) use to project source
-data into search indexes, knowledge graphs and [EDM](https://pro.europeana.eu/page/edm-documentation).
+inspectable – the Stack’s [SPARQL-native Transformation](../stack/patterns.md#sparql-native-transformation)
+pattern, used by its [pipelines](../stack/pipeline.md) to project source data into search indexes,
+knowledge graphs and [EDM](https://pro.europeana.eu/page/edm-documentation).
 
 When a source has several independently multi-valued properties, split the mapping into small
 `CONSTRUCT` queries joined by `UNION` rather than one query full of `OPTIONAL`s, so multi-valued


### PR DESCRIPTION
## What

Adds a **SPARQL-native Transformation** pattern to the Stack patterns, giving the Transform-stage technique its own named home instead of the one oblique clause it had inside *Configurable Pipeline*.

The pattern captures:
- **SPARQL `CONSTRUCT` as the transform step** — the query *is* the mapping spec; prefer several small chained `CONSTRUCT`s over one monolith.
- **UNION-not-OPTIONAL discipline** — split independently multi-valued properties into `UNION` branches so they don’t multiply into cross-product duplicates.
- **Non-RDF reach via SPARQL Anything (Facade-X)** — CSV/TSV/JSON/XML/Excel transformed with the same `CONSTRUCT`, no separate toolchain.
- **Fallback to [Ports & Adapters](https://docs.nde.nl/stack/patterns/#adapters)** — logic SPARQL can’t express moves to a named adapter boundary, not procedural glue.

## Integration
- Registered in the pattern-relationships mermaid map (`realised by` / `supplemented by` edges) with matching vocabulary entries.
- Pointer added from **Configurable Pipeline**.
- Cross-linked with the consumer how-tos **Use → Access** and **Use → Transform** (the latter now references the pattern instead of only the pipeline chapter).

## Wording refinement
- The Ports & Adapters relationship is now framed as **“supplemented by”** rather than “escapes to” throughout — the pattern-summary line, the mermaid edge, its vocabulary entry, and the Mechanics bullet — reading it as a complement to the SPARQL-native approach rather than an escape hatch.
- Minor prose tightening: em/en dashes to colons, and dropping the redundant realisation clause on the Configurable Pipeline pointer.

## Notes
- Anchors verified against existing headings (`#configurable-pipeline`, `#adapters`, `#schema-ap-nde-first`, `pipeline.md#example-edm-export-loda-pipeline`). `#adapters` is an explicit Docusaurus heading id (`## Ports & Adapters {#adapters}`), so it resolves on the site even though IDE markdown linters that only compute auto-slugs flag it. Static check only; no local Docusaurus build run.
