### PR TITLE
docs(blog): note SPARQL Anything 1.2 fixes in the GeoNames post

### DIFF
--- a/blog/2026-06-25-geonames-linked-data.md
+++ b/blog/2026-06-25-geonames-linked-data.md
@@ -54,7 +54,7 @@ WHERE {
     fx:properties fx:location "geonames.tsv" ;
       fx:csv.delimiter "\t" ;
       fx:csv.headers true ;
-      fx:csv.quote-char "\u0001" . # quote bugfix, see below
+      fx:csv.quote-char "false" . # GeoNames TSV is unquoted; see below
     ?s xyz:geonameid ?id ;
       xyz:name ?name ;
       xyz:alternatenames ?alts .
@@ -73,7 +73,7 @@ Note that we reuse the existing GeoNames IRIs (`https://sws.geonames.org/{id}/`)
 You run it from the command line:
 
 ```bash
-$ java -jar sparql-anything-v1.1.0.jar -q places.rq -f NT -o geonames.nt
+$ java -jar sparql-anything.jar -q places.rq -f NT -o geonames.nt
 ```
 
 ## What sits in between: Facade-X
@@ -192,19 +192,20 @@ And then the goal is reached: GeoNames is searchable in the Network of Terms.
 
 The build stage runs on a free GitHub-hosted runner (public repos): 4 vCPUs, **16 GB of RAM** and **14 GB of SSD**, and both the memory and the disk became ceilings.
 
-- **Memory.** The dataset is too large to load in one go on the runner. You would hope SPARQL Anything streams, but `fx:slice true` slices per row, which is unusably slow. 
-- **Disk.** Can we spare memory by spilling to disk? `fx:ondisk` first materialises *all* triples, and the on-disk store grew without bound, straight past the runner’s 14 GB. On roomier hardware we watched it reach **51 GB** with still no output after 2h before we killed it.
+- **Memory.** The dataset was too large to load in one go, and at the time SPARQL Anything could not stream a CSV in usable batches: `fx:slice true` sliced one row per query, unusably slow.
+- **Disk.** Spilling to disk did not help: `fx:ondisk` first materialises *all* triples, and the on-disk store grew without bound, straight past the runner’s 14 GB. On roomier hardware we watched it reach **51 GB** with still no output after 2h before we killed it.
 
-The solution to both we had to find **outside** SPARQL Anything: split the TSV first (`split -l 1M`) and call SPARQL Anything once per chunk. The price is paying the JVM startup time more often, but all in all we process the entire dump in **~75 min** on limited hardware. We proposed a configurable slice size `fx:slice n` upstream ([#624](https://github.com/SPARQL-Anything/sparql.anything/issues/624)), now on the milestone for the next release.
+We reported the missing per-query batch size as [#624](https://github.com/SPARQL-Anything/sparql.anything/issues/624), and **SPARQL Anything 1.2 added it**: `fx:slice.size 1000` streams a source in batches of 1000 rows, mapping a 1M-row chunk about **7× faster** at lower memory. We still split the TSV first (`split -l 1M`) and run one chunk per process, though – the `CONSTRUCT` output is assembled in memory before it is written (so peak memory tracks the *total* output, which we reported separately as [#635](https://github.com/SPARQL-Anything/sparql.anything/issues/635)), and a fresh JVM per chunk is what caps that. Split and slice do different jobs: **slice for speed, split for memory.**
 
 ## Verify
 
 But when chunking, make sure that **every chunk actually succeeded.**
 
-The GeoNames TSV does not use quoting, so a literal `"` is just an ordinary character inside a name; think `"Kostas Tsianos" Theatre`.
-But SPARQL Anything runs the TSV through Apache Commons CSV *with quoting enabled* and offers no off switch, so the `"` is read as a quote character and the parser crashes with `invalid char between encapsulated token and delimiter`.
+The GeoNames TSV does not use quoting, so a literal `"` is just an ordinary character inside a name; think `"Kostas Tsianos" Theatre`. But SPARQL Anything runs the TSV through Apache Commons CSV, which treats `"` as a quote by default, so it reads that name as a broken quoted field and crashes with `invalid char between encapsulated token and delimiter`. The fix is to turn quoting off with `fx:csv.quote-char "false"`, so `"` is read as ordinary data.
 
-The workaround is `fx:csv.quote-char "\u0001"`, pointing the quote character at a control character (U+0001, Start of Heading) that never occurs in the data, effectively turning quoting off. The real fix would be a proper off switch, which we filed as [#625](https://github.com/SPARQL-Anything/sparql.anything/issues/625).
+:::note[How we got here]
+`"false"` only arrived in **SPARQL Anything 1.2**, after we reported the missing off switch as [#625](https://github.com/SPARQL-Anything/sparql.anything/issues/625). Until then there was no way to disable quoting, so we worked around it by pointing `fx:csv.quote-char` at U+0001 (Start of Heading): a control character that never occurs in the data, which effectively turned quoting off.
+:::
 
 What did this cost?
 On 30 Nov 2025 the output had 12.27M features; with the quote fix it was 13.33M: about 1.06M extra places recovered. 


### PR DESCRIPTION
Updates the [Turning GeoNames into linked data](/blog/2026/06/25/geonames-linked-data) post for **SPARQL Anything 1.2**, which fixed two gaps we reported while building the pipeline.

Rather than bolt "Update" notes on top of the old workarounds, the post now leads with the current configuration and keeps the pre-1.2 history as context — so new readers see the right config first instead of an example that no longer matches how we run it:

- **Quoting ([#625](https://github.com/SPARQL-Anything/sparql.anything/issues/625))** — the main text now uses `fx:csv.quote-char "false"`; a "How we got here" note explains the old U+0001 control-character workaround.
- **Memory/throughput ([#624](https://github.com/SPARQL-Anything/sparql.anything/issues/624))** — the "Hitting the limits" resolution now describes `fx:slice.size 1000` (drops `fx:ondisk`, ~7× faster per chunk) while keeping `split` as the memory fence, with the remaining in-memory output limit noted as [#635](https://github.com/SPARQL-Anything/sparql.anything/issues/635).
- The headline query example and run command are updated to match (`"false"`, generic `sparql-anything.jar`).

## Coordination

Lands together with the pipeline change that adopts these fixes: **netwerk-digitaal-erfgoed/geonames-rdf#35** (draft, blocked on the first SPARQL Anything v1.2-DEV nightly that contains both). Kept draft until that merges, so the post doesn't describe an approach that isn't running yet.
