### PR TITLE
docs: drop keywords from the dataset-register data model

### DIFF
--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -62,7 +62,6 @@ both `dcat:Dataset` and `schema:Dataset` descriptions.
 | [`dcat:theme`](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#dataset-theme) | IRI from a controlled vocabulary; the [EU Data Theme NAL](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/data-theme) value `data-theme/EDUC` is auto-assigned | 1..n |
 | [`dcat:contactPoint`](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#dataset-contact-point) | `vcard:Kind` with `vcard:fn` and `vcard:hasEmail` (`mailto:` IRI) | 0..1<br />**v2.0**: 1..1 |
 | [`dct:language`](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#dataset-language) | [EU Language Authority](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language) IRI | 0..n |
-| [`dcat:keyword`](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#dataset-keyword) | `rdf:langString` | 0..n |
 | [`dcat:landingPage`](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#dataset-landing-page) | IRI | 0..n |
 | [`dct:source`](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#dataset-source) | IRI | 0..n |
 | `dct:created` <span class="vocab-tag">DC</span> | `xsd:date` or `xsd:dateTime`; the lexical form may not be ISO 8601 in v1.<br />**v2.0**: ISO 8601 value required | 0..1 |

--- a/docs/use/discover.md
+++ b/docs/use/discover.md
@@ -49,7 +49,7 @@ human-readable search interface with facets for publisher, terminology source, s
 **If you are automating**, query the Register’s
 [SPARQL endpoint](../services/dataset-register/sparql.md). It exposes every registered description in
 [DCAT](../services/dataset-register/data-model.md), so you can narrow the list at query time – by
-keyword, publisher, subject, `dcterms:conformsTo`, or validation status – instead of fetching
+publisher, subject, `dcterms:conformsTo`, or validation status – instead of fetching
 everything and filtering afterwards. Usually you want valid datasets only, so that you skip any whose
 latest fetch failed to produce a valid description; the
 [registration-status](../services/dataset-register/sparql.md#registration-status) section shows that


### PR DESCRIPTION
Mirrors dropping keywords from the dataset requirements (see netwerk-digitaal-erfgoed/dataset-register#1412 and its keyword-removal PR).

- **data-model.md**: remove the `dcat:keyword` property row from the `dcat:Dataset` table – the register no longer stores or exposes keywords.
- **discover.md**: drop `keyword` from the list of properties you can narrow a SPARQL query by.

Scoped to just the keyword removal; no other edits.
