### PR TITLE
docs(dataset-register): say what happens to a rejected submission

### DIFF
--- a/docs/publish/register.md
+++ b/docs/publish/register.md
@@ -6,3 +6,44 @@ slug: /register
 # Register Datasets
 
 Register your datasets with the NDE Dataset Register.
+
+## What happens after you register
+
+You register a **URL** that points to one or more dataset descriptions, not the descriptions
+themselves. The Register fetches that URL, [validates](../services/dataset-register/validation.md) what it finds,
+and only then stores it.
+
+* **If your description is valid**, the URL is registered and you are done. The Register re-crawls
+  it daily to pick up your changes, so you do not have to register again when a description
+  changes.
+* **If your description is invalid**, the registration is refused and *nothing is kept*: 
+  the Register will not come back to your URL by itself. Once you have fixed the problem, you have to register the
+  URL again.
+
+Registering the same URL twice is harmless, so when in doubt, register again.
+
+:::caution
+
+A description can be refused for a reason that is not in the description itself. If it declares a
+distribution (a data dump or a SPARQL endpoint) that the Register cannot reach at that moment, the
+description is refused as invalid even if the metadata is perfectly fine. If you cannot offer a
+service reliably, do not declare it: removing an unreliable SPARQL endpoint from the description is
+enough to make it registrable.
+
+Note the asymmetry: an unreachable distribution blocks a *new* registration, but only raises a
+warning on one that already exists. See [Validation](../services/dataset-register/validation.md#distribution-health).
+
+:::
+
+## Check before you register
+
+Because a refused submission leaves no trace, check the description before registering it, with the
+[validation web service](https://datasetregister.netwerkdigitaalerfgoed.nl/validate) or the
+[validation endpoints](../services/dataset-register/api.md). They apply the same rules as
+registration, including the distribution checks, so they tell you in advance whether registration
+would succeed.
+
+If you publish through a [collection management system](../glossary.md#collection-management-system),
+it should be doing this for you and showing you the result: that is
+[required](https://docs.nde.nl/requirements-dataset-register-implementations/) of it. If it lets you
+believe a description was registered when it was refused, report it to your supplier.

--- a/docs/services/dataset-register/data-model.md
+++ b/docs/services/dataset-register/data-model.md
@@ -119,14 +119,17 @@ dataset description that consumers query.
 
 ### `schema:EntryPoint`
 
-Any URL [registered by clients](api.md) is added as a `schema:EntryPoint` to the
-[Registrations graph](https://qlever.netwerkdigitaalerfgoed.nl/datasetregister/NwXonb?exec=true).
+A URL [registered by clients](api.md) is added as a `schema:EntryPoint` to the
+[Registrations graph](https://qlever.netwerkdigitaalerfgoed.nl/datasetregister/NwXonb?exec=true)
+once its description passes validation. A submission that is
+[rejected](validation.md#what-happens-to-a-rejected-submission) with HTTP `400` is not stored,
+so it never appears here.
 
 Datasets are fetched from this URL on registration and when the crawler runs.
 
 | Property                                                     | Description                                                                                                                                                                                                                                                                                                    |
 | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`schema:additionalType`](https://schema.org/additionalType) | Computed registration status:<ul><li>`<https://data.netwerkdigitaalerfgoed.nl/registry/valid>` — fetched and passed SHACL validation</li><li>`<https://data.netwerkdigitaalerfgoed.nl/registry/invalid>` — fetched but failed SHACL validation; see `schema:validUntil`</li><li>`<https://data.netwerkdigitaalerfgoed.nl/registry/gone>` — could not be fetched as a dataset description. Covers HTTP error responses (≥ 300) **and** non‑HTTP failures: parse errors, unrecognised content types, and URLs that returned 200 but contained no dataset triples.</li></ul> |
+| [`schema:additionalType`](https://schema.org/additionalType) | Computed registration status:<ul><li>`<https://data.netwerkdigitaalerfgoed.nl/registry/valid>` — fetched and passed SHACL validation</li><li>`<https://data.netwerkdigitaalerfgoed.nl/registry/invalid>` — was registered successfully but has since failed SHACL validation at a later crawl; see `schema:validUntil`. A submission rejected at registration is never stored, so this status never denotes one</li><li>`<https://data.netwerkdigitaalerfgoed.nl/registry/gone>` — could not be fetched as a dataset description. Covers HTTP error responses (≥ 300) **and** non‑HTTP failures: parse errors, unrecognised content types, and URLs that returned 200 but contained no dataset triples.</li></ul> |
 | [`schema:datePosted`](https://schema.org/datePosted)         | UTC datetime when the URL was registered.                                                                                                                                                                                                                                                                      |
 | [`schema:dateRead`](https://schema.org/dateRead)             | UTC datetime when the URL was last read by the application. The crawler updates this value when fetching descriptions.                                                                                                                                                                                         |
 | [`schema:status`](https://schema.org/status)                 | The HTTP status code last encountered when fetching the URL.                                                                                                                                                                                                                                                   |

--- a/docs/services/dataset-register/validation.md
+++ b/docs/services/dataset-register/validation.md
@@ -42,6 +42,20 @@ So a `200` or `202` response can still carry a report with `sh:conforms = false`
 In short: use the status code to keep or reject; surface anything else in the report body to
 the editor as advisory feedback.
 
+## What happens to a rejected submission
+
+A `400` is final for that submission. The Register stores nothing on the rejection path: no registration record, no pending queue, no scheduled retry. Only a description that passes validation is written to the [Registrations graph](data-model.md#schemaentrypoint), and the crawler only ever re-fetches URLs it finds there. A rejected URL is therefore never re-checked, not after 24 hours and not ever: nothing picks it up by itself once the underlying problem is fixed.
+
+To register the description, fix what the report lists and call `POST /datasets` again. That call is idempotent, so re-submitting is both safe and necessary.
+
+This applies to a URL that is not yet registered. Re-submitting a URL that is **already** registered leaves its existing registration untouched: the `400` changes nothing, and the crawler keeps re-fetching that registration on its normal schedule.
+
+:::note
+
+Because rejected submissions leave no trace, the Register cannot report which descriptions were turned away, or how many. A publisher who does not act on the `400` is invisible to it. This is why the [Requirements for Dataset Register Implementations](https://docs.nde.nl/requirements-dataset-register-implementations/) place the duty to surface validation results on the [collection management system](../../glossary.md#collection-management-system).
+
+:::
+
 ## Validating against the SHACL shape directly
 
 If you fetch the shape graph from `GET /shacl` and run validation in your own pipeline (e.g.
@@ -70,7 +84,7 @@ The Register models a distribution’s health as a derived **usability** verdict
 - **reachability** – can the distribution be fetched? (HTTP/SPARQL level)
 - **validity** – does the fetched content actually parse as RDF?
 
-During validation the Register probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to produce both signals: it checks that the URL is reachable and serves the declared media type (reachability), and, for small RDF dumps (≤ 10 KB Turtle / N-Triples / N-Quads), that the body parses as RDF (validity). Even when the description passes SHACL, a broken or mistyped distribution URL, or a body that does not parse as RDF, is reported as a `sh:Violation` and rejected with HTTP `400` — so fix it before (re)submitting.
+During validation the Register probes every distribution URL it can derive from the description (`dcat:accessURL`, `dcat:downloadURL`, `schema:contentUrl`) to produce both signals: it checks that the URL is reachable and serves the declared media type (reachability), and, for small RDF dumps (≤ 10 KB Turtle / N-Triples / N-Quads), that the body parses as RDF (validity). Even when the description passes SHACL, a broken or mistyped distribution URL, or a body that does not parse as RDF, is reported as a `sh:Violation` and rejected with HTTP `400` — so fix it before [(re)submitting](#what-happens-to-a-rejected-submission).
 
 :::note
 


### PR DESCRIPTION
A submission that fails validation is discarded: nothing is stored, nothing is queued, and the crawler never comes back to it. The publisher has to register the URL again. That was documented nowhere, and the data model chapter implied the opposite.

Context: netwerk-digitaal-erfgoed/dataset-register#2260, where the question came up whether a registration refused for an unreachable SPARQL endpoint is automatically re-checked every 24 hours. It is not. This PR documents the behaviour; it does not change it, and it takes no position on the open question of whether registration should be that strict.

## Changes

**`services/dataset-register/data-model.md`** – corrects a claim that was simply wrong. It said *any* URL registered by clients is added to the registrations graph; only a URL whose description passes validation is. Combined with the documented `invalid` registration status, that wording implied refused submissions are kept and re-crawled, which is the opposite of what happens. Also rewrites the `invalid` status: it marks a registration that broke *after* being accepted, never one refused at submission.

**`services/dataset-register/validation.md`** – adds `What happens to a rejected submission`, placed under `Calling the API` because it applies to every `400`, not just probe failures. Says plainly that nothing is retained, that a rejected URL is never re-checked, that re-registering is safe and necessary, and that an already-registered URL is unaffected. Notes that the register therefore cannot report what it turned away.

**`publish/register.md`** – was a one-line stub. Gives publishers the same answer without the API vocabulary: valid means re-crawled daily, invalid means nothing is kept and you register again. Flags the asymmetry that an unreachable distribution refuses a *new* registration but only warns on an existing one, and points at the validation service. This does not yet make it the full canonical registration page.
