### PR TITLE
docs(stack): distinguish the Stack from the network services it builds on

### DIFF
--- a/docs/stack/index.md
+++ b/docs/stack/index.md
@@ -12,6 +12,7 @@ This chapter proposes engineering choices, naming conventions, and operational p
 
 The **NDE Stack** is the working name given here to the **ecosystem of [NDE-compatible](../glossary.md#nde-compatible) [components](#components)** and the **[operational patterns](patterns.md)** that compose them, grounded in the network’s shared standards.
 The Stack’s goal is to **help software developers in the NDE network solve shared functionality once** rather than reinventing it in each project.
+It is what NDE offers builders to work *with*; the NDE-operated [network services](#taxonomy) it works *on* – the [Dataset Register](../services/dataset-register/), [Network of Terms](../services/network-of-terms/), and [Dataset Knowledge Graph](../services/dataset-knowledge-graph/) – are composed and consumed, not part of the Stack a builder deploys.
 Most of what appears here is new: proposed components and patterns yet to be built.
 The rest is existing software given a role in the Stack.
 
@@ -42,13 +43,13 @@ The Stack uses a small vocabulary consistently.
 | **Component** | Software the Stack provides | `@lde/*` packages, `@ndes/*` packages                                                                                                                                 |
 | **Pattern** | Operational mechanic | [Blue/green Rebuild](patterns.md#bluegreen-rebuild), [SCHEMA-AP-NDE-first](patterns.md#schema-ap-nde-first), [Ports & Adapters](patterns.md#adapters)                        |
 | **Service** | A running instance of a Component, deployed with a specific configuration | A [Service Platform](../glossary.md#service-platform) running the search projection with its own SHACL and search configuration                                       |
-| **Network service** | A Service operated by NDE, network-wide, addressable as a single canonical endpoint | [Dataset Register](../services/dataset-register/), [Network of Terms](../services/network-of-terms/), [Dataset Knowledge Graph](../services/dataset-knowledge-graph/) |
+| **Network service** | An NDE-operated, network-wide endpoint the Stack **builds on** rather than provides: consumed via its canonical URL, not deployed by Stack users | [Dataset Register](../services/dataset-register/), [Network of Terms](../services/network-of-terms/), [Dataset Knowledge Graph](../services/dataset-knowledge-graph/) |
 | **Standard** | A network commitment the Stack adopts | SCHEMA-AP-NDE, LDES, IIIF, DCAT-AP 3.0 / Schema.org Dataset                                                                                                        |
 | **Foundational technology** | Upstream open-source dependency outside NDE governance | QLever, Typesense, nginx, Fastify, Mercurius                                                                                                                          |
 
 ## Components
 
-The Stack provides the components below. They live in the [Service Platform side](layers/platform.md) chapter; this catalog is a quick index. The [Pipeline](pipeline.md) chapter shows how the pipeline components compose.
+The Stack provides the components below – the software a builder deploys. These are distinct from the [network services](#taxonomy) NDE operates and the Stack builds on: where a component below reaches a network service, the service is consumed, not part of the deployed Stack. The [DKG](../services/dataset-knowledge-graph/), for instance, is a network service reached through the Knowledge Graph APIs, not a component a builder runs. They live in the [Service Platform side](layers/platform.md) chapter; this catalog is a quick index, and the [Pipeline](pipeline.md) chapter shows how the pipeline components compose.
 
 | Component | Layer | Brief |
 | --- | --- | --- |

--- a/docs/stack/layers/index.md
+++ b/docs/stack/layers/index.md
@@ -20,7 +20,7 @@ The NDE network architecture distinguishes four layers. This chapter consolidate
 The [NDE Stack](../) covers all four layers. It is positioned around the full Linked Data lifecycle the same way Linked Data Elements ([LDE](https://github.com/ldelements/lde)) is (Discovery / Ingestion / Transformation / Analysis / Publication / Serve).
 LDE is a toolkit of small, composable `@lde/*` packages that handle generic linked-data plumbing:
 discovering datasets, downloading distributions, running pipelines, serving SPARQL and RDF. It is data-model-agnostic and network-agnostic.
-The NDE Stack composes LDE’s packages with NDE-specific configuration (`@ndes/*`) and operated [network services](../../services/) to produce the NDE approach of the lifecycle.
+The NDE Stack composes LDE’s packages with NDE-specific configuration (`@ndes/*`), building on NDE’s operated [network services](../../services/) to produce the NDE approach of the lifecycle.
 
 ## In this chapter
 


### PR DESCRIPTION
The Stack chapter said two contradictory things about whether the NDE-operated network services (Dataset Register, Network of Terms, DKG) are part of the Stack:

- **Part of it.** The taxonomy defined `Network service` as "A Service operated by NDE", and `Service` as "a running instance of a Component", and `Component` as "software the Stack provides" – so by its own chain a network service was a kind of Stack component. The layers overview said the Stack "composes … operated network services", i.e. they are made *into* it.
- **Separate from it.** The stated goal – "help software developers solve shared functionality once" – frames the Stack as tooling a builder picks up, with the network services as things it consumes.

This resolves it in favour of the second reading: **the Stack is what NDE offers builders to work *with*; the network services are what it builds *on*.**

## Changes

- **Definition** now states the boundary at first mention: the Stack is what NDE offers builders to work with, and the NDE-operated network services are composed and consumed, not part of the Stack a builder deploys.
- **Taxonomy** redefines `Network service` as "an NDE-operated, network-wide endpoint the Stack builds on rather than provides", breaking the old `Network service` → `Service` → `Component` chain.
- **Components catalog** notes that where a component reaches a network service, the service is consumed, not part of the deployed Stack – the DKG is reached through the Knowledge Graph APIs, not run by a builder.
- **Layers overview** reframed: the Stack builds on operated network services rather than composing them in.

Comes out of the Stack review (#136); the same boundary underlies several of its open questions (S9, S12).
