### PR TITLE
docs(dataset-register): document the typed search filters and IRI buckets

### DIFF
--- a/docs/services/dataset-register/graphql.md
+++ b/docs/services/dataset-register/graphql.md
@@ -84,10 +84,17 @@ datasets(
 ): DatasetSearchResult!
 ```
 
-- **`where`** filters by exact values. Keyword-style fields (`id`, `publisher`, `format`, `class`,
-  `terminology_source`, `catalog`, `status`) take a `StringFilter` – `{ in: […] }`,
-  which unions the listed values – and `size` takes an `IntRange` (`{ min, max }`). For example,
-  `where: { format: { in: ["group:rdf"] } }` returns datasets with any RDF distribution.
+- **`where`** filters by exact values. Every filter is `{ in: […] }`, which unions the listed
+  values; its *type* says what those values are:
+  - **IRIs** – `id` (`DatasetFilter`), `publisher` (`AgentFilter`), `terminology_source`
+    (`VocabularyFilter`), and `class` and `catalog` (`IRIFilter`, where no entity type names
+    them). These also accept the `group:…` tokens the Register mints alongside real IRIs
+    (`group:person` on `class`): they are absolute IRIs in their own right.
+  - **Tokens** – `format` and `status` (`KeywordFilter`).
+  - `size` takes an `IntRange` (`{ min, max }`).
+
+  For example, `where: { format: { in: ["group:rdf"] } }` returns datasets with any RDF
+  distribution.
   The automated checks the Register performs on the datasets themselves are boolean fields and
   take a plain `Boolean`: `where: { nde_schema_ap: true }` returns the datasets of which a sample
   of the resources conforms to the NDE Schema.org Application Profile.
@@ -119,7 +126,9 @@ lookup to render a facet or a result card.
 
 Three bucket shapes appear, by the kind of field faceted:
 
-- **`ValueBucket`** (`value: String!`, `count`, optional `label`) for the keyword and IRI facets;
+- **`IRIBucket`** (`value: IRI!`, `count`, optional `label`) for the facets keyed on IRIs
+  (`publisher`, `class`, `terminology_source`), and **`ValueBucket`** (`value: String!`, the same
+  otherwise) for the token facets (`format`, `status`);
 - **`RangeBucket`** (`min`, `max`, `count`) for `size`, which facets into fixed bins rather than
   one bucket per value;
 - **`BooleanBucket`** (`value: Boolean!`, `count`) for the automated-check facets (`iiif`,


### PR DESCRIPTION
Follows netwerk-digitaal-erfgoed/dataset-register#2317, which takes the `@lde/search` 0.21 bump and changes the published contract.

`StringFilter` is gone. Each filter is now typed by what its field keys on — IRI-valued fields take an `IRIFilter`, or an entity-named `DatasetFilter` / `AgentFilter` / `VocabularyFilter`; token fields take a `KeywordFilter`. The facets keyed on IRIs return an `IRIBucket` carrying the new `IRI` scalar, alongside `ValueBucket` for the token facets.

The `{ in: [...] }` shape is unchanged, so this only affects consumers that name the types.

Also spells out the part most likely to trip someone filtering the class facet: an IRI-valued filter still accepts the `group:…` tokens the Register mints beside real IRIs, because those are absolute IRIs in their own right.